### PR TITLE
Add support for DataSets

### DIFF
--- a/OEMock/Inspection/BaseInspector.cls
+++ b/OEMock/Inspection/BaseInspector.cls
@@ -137,6 +137,111 @@ CLASS OEMock.Inspection.BaseInspector:
 	    RETURN parm.
 	END METHOD.
 	
+	METHOD PROTECTED OEMock.Reflection.DataSet CreateDataSet(INPUT hNodeRef AS HANDLE, INPUT objId AS CHARACTER):
+	    
+	    DEFINE VARIABLE DSet       AS OEMock.Reflection.DataSet NO-UNDO.
+	    DEFINE VARIABLE DRel       AS OEMock.Reflection.DataSetRelation NO-UNDO.
+	    DEFINE VARIABLE AccessMode AS CHARACTER NO-UNDO. 
+	    DEFINE VARIABLE hNode      AS HANDLE    NO-UNDO.
+	    DEFINE VARIABLE hChildNode AS HANDLE    NO-UNDO.
+	    DEFINE VARIABLE iNode      AS INTEGER   NO-UNDO.
+	    DEFINE VARIABLE iChildNode AS INTEGER   NO-UNDO.
+	    
+	    CREATE X-NODEREF hNode.
+	    CREATE X-NODEREF hChildNode.
+	    
+	    DSet = NEW OEMock.Reflection.DataSet(objId).
+	    
+        DO iNode = 1 TO hNodeRef:NUM-CHILDREN:
+            hNodeRef:GET-CHILD(hNode, iNode).
+            IF hNode:SUBTYPE NE "ELEMENT" THEN NEXT.
+            CASE hNode:NAME:
+                WHEN "Access-mode" THEN
+                DO:
+                    hNode:NORMALIZE().
+                    ASSIGN AccessMode = ExtractTextValue(hNode).
+                END.
+                WHEN "Is-static" THEN
+                DO:
+                    hNode:NORMALIZE().
+                    ASSIGN DSet:Static = (ExtractTextValue(hNode) = "true").
+                END.
+                WHEN "Dataset-Ref" THEN
+                DO:
+                    /* Dataset-Ref holds useful information about the Dataset
+                     * e.g. buffer lists, relations, etc.
+                     */
+                    DO iChildNode = 1 TO hNode:NUM-CHILDREN:
+                        hNode:GET-CHILD(hChildNode, iChildNode).
+                        IF hNode:SUBTYPE NE "ELEMENT" THEN NEXT.
+                        CASE hChildNode:NAME:
+                            WHEN "Buffer-list" THEN
+                            DO:
+                                DSet:Buffers = ExtractTextValue(hChildNode).
+                            END.
+                            WHEN "N-prefix" THEN
+                            DO:
+                                DSet:NamespacePrefix = ExtractTextValue(hChildNode).
+                            END.
+                            WHEN "N-uri" THEN
+                            DO:
+                                DSet:NamespaceURI = ExtractTextValue(hChildNode).
+                            END.
+                            WHEN "Relation" THEN
+                            DO:
+                                DRel = CreateDataSetRelation(hChildNode).
+                                IF VALID-OBJECT(DRel) THEN 
+                                    DSet:DataSetRelations:AddDataSetRelation(DRel).
+                            END.
+                        END CASE.
+                    END.
+                END.
+            END CASE.
+        END.
+
+        /* If this is a private object, then return an invalid object */
+        IF AccessMode EQ "PRIVATE" THEN DELETE OBJECT DSet NO-ERROR.
+	    
+	    RETURN DSet.
+	    
+	END METHOD.
+	
+	METHOD PRIVATE OEMock.Reflection.DataSetRelation CreateDataSetRelation(INPUT hNodeRef AS HANDLE):
+	    
+	    DEFINE VARIABLE DRel AS OEMock.Reflection.DataSetRelation NO-UNDO.
+        DEFINE VARIABLE hNode      AS HANDLE    NO-UNDO.
+        DEFINE VARIABLE iNode      AS INTEGER   NO-UNDO.
+        
+        CREATE X-NODEREF hNode.
+	    
+	    DRel = NEW OEMock.Reflection.DataSetRelation(hNodeRef:GET-ATTRIBUTE("Relation-name")).
+	    
+	    DO iNode = 1 TO hNodeRef:NUM-CHILDREN:
+            hNodeRef:GET-CHILD(hNode, iNode).
+            IF hNode:SUBTYPE NE "ELEMENT" THEN NEXT.
+            CASE hNode:NAME:
+                WHEN "Parent-buffer-name" THEN
+                DO:
+                    hNode:NORMALIZE().
+                    ASSIGN DRel:ParentBufferName = ExtractTextValue(hNode).
+                END.
+                WHEN "Child-buffer-name" THEN
+                DO:
+                    hNode:NORMALIZE().
+                    ASSIGN DRel:ChildBufferName = ExtractTextValue(hNode).
+                END.
+                WHEN "Relation-list" THEN
+                DO:
+                    hNode:NORMALIZE().
+                    ASSIGN DRel:RelationList = ExtractTextValue(hNode).
+                END.
+            END CASE.
+        END.
+	    
+	    RETURN DRel.
+	    
+	END METHOD.
+	
 	METHOD PROTECTED LONGCHAR ExtractTextValue(INPUT hNodeRef AS HANDLE):
 	    DEFINE VARIABLE res       AS LONGCHAR NO-UNDO.
 	    DEFINE VARIABLE hTextNode AS HANDLE NO-UNDO.

--- a/OEMock/Inspection/BaseInspector.cls
+++ b/OEMock/Inspection/BaseInspector.cls
@@ -102,6 +102,7 @@ CLASS OEMock.Inspection.BaseInspector:
 	    
 	    DEFINE VARIABLE parm AS BaseParameter NO-UNDO.
 	    DEFINE VARIABLE primparm AS PrimitiveParameter NO-UNDO.
+	    DEFINE VARIABLE dsetparm AS DataSetParameter   NO-UNDO.
 	    DEFINE VARIABLE tableparm AS TableParameter NO-UNDO.
 	    
 	    /* Factory method. Based on the information passed through hParamNode,
@@ -121,6 +122,12 @@ CLASS OEMock.Inspection.BaseInspector:
                 tableparm = NEW OEMock.Reflection.TableParameter(ParamType).
                 tableparm:ParameterType = ParamMode.
                 parm = tableparm.
+            END.
+            ELSE IF ParamMode = "DATASET" THEN
+            DO:
+                dsetparm = NEW OEMock.Reflection.DataSetParameter(ParamName).
+                dsetparm:ParameterType = ParamMode.
+                parm = dsetparm.
             END.
             ELSE
 	        DO:

--- a/OEMock/Inspection/ClassInspector.cls
+++ b/OEMock/Inspection/ClassInspector.cls
@@ -35,6 +35,8 @@ CLASS OEMock.Inspection.ClassInspector INHERITS BaseInspector:
         DEFINE VARIABLE Meth       AS Method      NO-UNDO.
         DEFINE VARIABLE Const      AS CONSTRUCTOR NO-UNDO.
         
+        DEFINE VARIABLE DSet       AS OEMock.Reflection.DataSet NO-UNDO.
+        
         CREATE X-NODEREF hNode.
         CREATE X-NODEREF hChildNode.
 
@@ -96,6 +98,15 @@ CLASS OEMock.Inspection.ClassInspector INHERITS BaseInspector:
                 END.
                 
                 BuiltClass:Constructors:AddMethod(Const).
+            END.
+            
+            WHEN "DATASET" THEN
+            DO:
+                /* Use parent method to interpret into a DataSet object */
+                DSet = CreateDataSet(hRefNode, objId).
+
+                /* If valid object, then add to list of DataSets */
+                IF VALID-OBJECT(DSet) THEN BuiltClass:DataSets:AddDataSet(DSet).
             END.
             
             WHEN "METHOD" THEN

--- a/OEMock/Inspection/ProcedureInspector.cls
+++ b/OEMock/Inspection/ProcedureInspector.cls
@@ -30,6 +30,7 @@ CLASS OEMock.Inspection.ProcedureInspector INHERITS BaseInspector:
         DEFINE VARIABLE AccessMode AS CHARACTER NO-UNDO.
         DEFINE VARIABLE Proc       AS Procedure NO-UNDO.
         DEFINE VARIABLE Func       AS Function  NO-UNDO.
+        DEFINE VARIABLE DSet       AS OEMock.Reflection.DataSet NO-UNDO.
 
         CREATE X-NODEREF hNode.
         
@@ -100,6 +101,15 @@ CLASS OEMock.Inspection.ProcedureInspector INHERITS BaseInspector:
                     BuiltProc:Functions:AddMethod(Func).
                 ELSE
                     DELETE OBJECT Func NO-ERROR.
+            END.
+            
+            WHEN "DATASET" THEN
+            DO:
+                /* Use parent method to interpret into a DataSet object */
+                DSet = CreateDataSet(hRefNode, objId).
+                
+                /* If valid object, then add to list of DataSets */
+                IF VALID-OBJECT(DSet) THEN BuiltProc:DataSets:AddDataSet(DSet).
             END.
         END CASE.
         

--- a/OEMock/Reflection/ClassFile.cls
+++ b/OEMock/Reflection/ClassFile.cls
@@ -8,6 +8,7 @@ USING OEMock.Reflection.BaseFile.
 USING OEMock.Reflection.MethodList.
 USING OEMock.Generation.GeneratorList.
 USING OEMock.Util.StringList.
+USING OEMock.Reflection.DataSetList.
 
 ROUTINE-LEVEL ON ERROR UNDO, THROW.
 
@@ -18,6 +19,10 @@ CLASS OEMock.Reflection.ClassFile INHERITS BaseFile:
     SET. 
 
     DEFINE PUBLIC PROPERTY Constructors AS OEMock.Reflection.MethodList NO-UNDO 
+    GET.
+    PROTECTED SET. 
+
+    DEFINE PUBLIC PROPERTY DataSets AS OEMock.Reflection.DataSetList NO-UNDO 
     GET.
     PROTECTED SET. 
 
@@ -63,7 +68,9 @@ CLASS OEMock.Reflection.ClassFile INHERITS BaseFile:
         Constructors = NEW MethodList().
         Methods      = NEW MethodList().
         Generators   = NEW GeneratorList().
-        Interfaces   = NEW StringList().       
+        Interfaces   = NEW StringList().
+        DataSets     = NEW DataSetList().
+             
     END CONSTRUCTOR.
 
     DESTRUCTOR PUBLIC ClassFile():
@@ -72,6 +79,7 @@ CLASS OEMock.Reflection.ClassFile INHERITS BaseFile:
         IF VALID-OBJECT(ClassRef)     THEN DELETE OBJECT ClassRef.
         IF VALID-OBJECT(Generators)   THEN DELETE OBJECT Generators.
         IF VALID-OBJECT(Interfaces)   THEN DELETE OBJECT Interfaces.
+        IF VALID-OBJECT(DataSets)     THEN DELETE OBJECT DataSets.
     END DESTRUCTOR.
     
     METHOD PROTECTED LONGCHAR GenerateClass():
@@ -81,14 +89,34 @@ CLASS OEMock.Reflection.ClassFile INHERITS BaseFile:
                               + "&1&5"
                               + "&1&6"
                               + "&1&7"
+                              + "&1&8"
                               + "&1END CLASS.&1",
                                 CHR(10) + CHR(13),
                                 IF INDEX(TypeName, " ") > 0 THEN '"' + TypeName + '"' ELSE TypeName,
                                 (IF InheritsFrom NE ? AND TRIM(InheritsFrom) NE "" THEN "INHERITS " + TRIM(InheritsFrom) + " " ELSE ""),
                                 GenerateInterfaces(),
+                                GenerateDataSets(),
                                 GenerateConstructors(),
                                 GenerateMethods(),
                                 Generators:Generate()).
+        RETURN res.
+    END METHOD.
+    
+    METHOD PROTECTED LONGCHAR GenerateDataSets():
+        DEFINE VARIABLE res  AS LONGCHAR NO-UNDO.
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        
+        /* Loop through datasets */
+        dset = DataSets:MoveFirst().
+        DO WHILE VALID-OBJECT(dset):
+            ASSIGN res  = res + dset:Generate()
+                        + CHR(10) + CHR(13)
+                   dset = DataSets:MoveNext().
+        END.
+        
+        /* Sanity check output */
+        IF res = ? THEN res = "".
+
         RETURN res.
     END METHOD.
     

--- a/OEMock/Reflection/DataSet.cls
+++ b/OEMock/Reflection/DataSet.cls
@@ -24,10 +24,15 @@ CLASS OEMock.Reflection.DataSet:
 	GET.
 	PROTECTED SET.
 	
+	DEFINE PUBLIC PROPERTY Static AS LOGICAL NO-UNDO INITIAL FALSE
+	GET.
+	SET.
+	
 	CONSTRUCTOR PUBLIC DataSet(INPUT nam AS CHARACTER):
 		SUPER().
 		
-		ASSIGN Name = nam.
+		ASSIGN Name   = nam
+		       Static = FALSE.
 		
 		/* Create objects */
 		ASSIGN DataSetRelations = NEW OEMock.Reflection.DataSetRelationList().
@@ -42,7 +47,8 @@ CLASS OEMock.Reflection.DataSet:
 	    DEFINE VARIABLE res AS LONGCHAR        NO-UNDO.
 	    DEFINE VARIABLE rel AS DataSetRelation NO-UNDO.
 	    
-	    res = SUBSTITUTE("DEFINE DATASET &1 FOR &2 ",
+	    res = SUBSTITUTE("DEFINE &1DATASET &2 FOR &3 ",
+	                     (IF THIS-OBJECT:Static THEN "STATIC " ELSE ""),
 	                     Name,
 	                     Buffers).
 	    

--- a/OEMock/Reflection/DataSet.cls
+++ b/OEMock/Reflection/DataSet.cls
@@ -1,0 +1,60 @@
+/*------------------------------------------------------------------------
+    File        : DataSet
+    Purpose     : Represents a DataSet in code. 
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEMock.Util.StringList.
+USING OEMock.Reflection.DataSetRelationList.
+USING OEMOck.Reflection.DataSetRelation.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Reflection.DataSet:
+    
+    DEFINE PUBLIC PROPERTY Buffers AS CHARACTER NO-UNDO
+    GET.
+    SET.
+    
+    DEFINE PUBLIC PROPERTY DataSetRelations AS OEMock.Reflection.DataSetRelationList NO-UNDO
+    GET.
+    PROTECTED SET.
+		
+	DEFINE PUBLIC PROPERTY Name AS CHARACTER NO-UNDO 
+	GET.
+	PROTECTED SET.
+	
+	CONSTRUCTOR PUBLIC DataSet(INPUT nam AS CHARACTER):
+		SUPER().
+		
+		ASSIGN Name = nam.
+		
+		/* Create objects */
+		ASSIGN DataSetRelations = NEW OEMock.Reflection.DataSetRelationList().
+	END CONSTRUCTOR.
+
+	DESTRUCTOR PUBLIC DataSet():
+        IF VALID-OBJECT(DataSetRelations) THEN DELETE OBJECT DataSetRelations.
+	END DESTRUCTOR.
+	
+	METHOD PUBLIC LONGCHAR Generate():
+	    
+	    DEFINE VARIABLE res AS LONGCHAR        NO-UNDO.
+	    DEFINE VARIABLE rel AS DataSetRelation NO-UNDO.
+	    
+	    res = SUBSTITUTE("DEFINE DATASET &1 FOR &2 ",
+	                     Name,
+	                     Buffers).
+	    
+	    /* Build list of data relations */
+	    rel = DataSetRelations:MoveFirst().
+	    DO WHILE(VALID-OBJECT(rel)):
+	        res = res + " " + rel:Generate().
+	        rel = DataSetRelations:MoveNext().
+	    END.
+	    
+	    RETURN res.
+	    
+	END METHOD.
+
+END CLASS.

--- a/OEMock/Reflection/DataSet.cls
+++ b/OEMock/Reflection/DataSet.cls
@@ -77,6 +77,9 @@ CLASS OEMock.Reflection.DataSet:
 	        rel = DataSetRelations:MoveNext().
 	    END.
 	    
+	    ASSIGN res = TRIM(TRIM(res,"."))
+	               + ".".
+	    
 	    RETURN res.
 	    
 	END METHOD.

--- a/OEMock/Reflection/DataSet.cls
+++ b/OEMock/Reflection/DataSet.cls
@@ -23,6 +23,18 @@ CLASS OEMock.Reflection.DataSet:
 	DEFINE PUBLIC PROPERTY Name AS CHARACTER NO-UNDO 
 	GET.
 	PROTECTED SET.
+        
+    DEFINE PUBLIC PROPERTY NamespacePrefix AS CHARACTER NO-UNDO 
+    GET.
+    SET.
+        
+    DEFINE PUBLIC PROPERTY NamespaceURI AS CHARACTER NO-UNDO 
+    GET.
+    SET.
+    
+    DEFINE PUBLIC PROPERTY Reference AS LOGICAL NO-UNDO INITIAL FALSE
+    GET.
+    SET.
 	
 	DEFINE PUBLIC PROPERTY Static AS LOGICAL NO-UNDO INITIAL FALSE
 	GET.
@@ -31,8 +43,11 @@ CLASS OEMock.Reflection.DataSet:
 	CONSTRUCTOR PUBLIC DataSet(INPUT nam AS CHARACTER):
 		SUPER().
 		
-		ASSIGN Name   = nam
-		       Static = FALSE.
+		ASSIGN Name            = nam
+		       NamespacePrefix = ""
+		       NamespaceURI    = ""
+               Reference       = FALSE
+               Static          = FALSE.
 		
 		/* Create objects */
 		ASSIGN DataSetRelations = NEW OEMock.Reflection.DataSetRelationList().
@@ -47,10 +62,13 @@ CLASS OEMock.Reflection.DataSet:
 	    DEFINE VARIABLE res AS LONGCHAR        NO-UNDO.
 	    DEFINE VARIABLE rel AS DataSetRelation NO-UNDO.
 	    
-	    res = SUBSTITUTE("DEFINE &1DATASET &2 FOR &3 ",
+	    res = SUBSTITUTE("DEFINE &1DATASET &2 FOR &3 &4&5&6",
 	                     (IF THIS-OBJECT:Static THEN "STATIC " ELSE ""),
 	                     Name,
-	                     Buffers).
+	                     Buffers,
+	                     (IF NamespacePrefix NE ? AND NamespacePrefix NE "" THEN "NAMESPACE-PREFIX ~"" + NamespacePrefix + "~" " ELSE ""),
+                         (IF NamespaceURI    NE ? AND NamespaceURI    NE "" THEN "NAMESPACE-URI ~""    + NamespaceURI    + "~" " ELSE ""),
+	                     (IF THIS-OBJECT:Reference THEN "REFERENCE-ONLY " ELSE "")).
 	    
 	    /* Build list of data relations */
 	    rel = DataSetRelations:MoveFirst().

--- a/OEMock/Reflection/DataSetList.cls
+++ b/OEMock/Reflection/DataSetList.cls
@@ -1,0 +1,51 @@
+ /*------------------------------------------------------------------------
+    File        : DataSetList
+    Purpose     : Holds list of DataSet objects
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEMock.Reflection.DataSet.
+USING OEMock.Util.BaseList.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Reflection.DataSetList INHERITS BaseList: 
+
+	CONSTRUCTOR PUBLIC DataSetList():
+		SUPER().
+	END CONSTRUCTOR.
+    
+    METHOD PUBLIC LOGICAL AddDataSet(INPUT fil AS DataSet):
+        RETURN SUPER:AddItem(fil).
+    END METHOD.
+    
+    METHOD OVERRIDE PUBLIC VOID EmptyList():
+        SUPER:EmptyList().
+    END METHOD.
+    
+    METHOD PROTECTED DataSet CastToDataSet(INPUT obj AS Progress.Lang.Object):
+        DEFINE VARIABLE res AS DataSet NO-UNDO.
+        IF VALID-OBJECT(obj) AND obj:GetClass():IsA("OEMock.Reflection.DataSet")THEN
+        DO:
+            res = DYNAMIC-CAST(obj, obj:GetClass():TypeName).
+        END.
+        RETURN res.
+    END METHOD.
+    
+    METHOD PUBLIC DataSet MoveFirst():
+        RETURN CastToDataSet(GetFirst()).
+    END METHOD.
+    
+    METHOD PUBLIC DataSet MoveLast():
+        RETURN CastToDataSet(GetLast()).
+    END METHOD.
+    
+    METHOD PUBLIC DataSet MoveNext():
+        RETURN CastToDataSet(GetNext()).
+    END METHOD.
+    
+    METHOD PUBLIC DataSet MovePrev():
+        RETURN CastToDataSet(GetPrev()).
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Reflection/DataSetParameter.cls
+++ b/OEMock/Reflection/DataSetParameter.cls
@@ -1,0 +1,56 @@
+/*------------------------------------------------------------------------
+    File        : DataSetParameter
+    Purpose     : Represents a DataSet parameter
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEMock.Reflection.BaseParameter.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Reflection.DataSetParameter INHERITS BaseParameter:
+
+    DEFINE PUBLIC PROPERTY ParameterType AS CHARACTER INITIAL "INPUT" NO-UNDO 
+    GET.
+    SET.
+
+    CONSTRUCTOR PUBLIC DataSetParameter(INPUT nam AS CHARACTER):
+        SUPER(INPUT nam).
+        ASSIGN ParameterType = "INPUT".
+    END CONSTRUCTOR.
+        
+    CONSTRUCTOR PUBLIC DataSetParameter():
+        THIS-OBJECT("").
+    END CONSTRUCTOR.
+    
+    METHOD OVERRIDE PUBLIC CHARACTER GenerateDefinition():
+        DEFINE VARIABLE parm AS CHARACTER NO-UNDO.
+        
+        IF  TRIM(Name)          NE "" AND Name          NE ?
+        AND TRIM(ParameterType) NE "" AND ParameterType NE ? THEN
+        DO: 
+            ASSIGN parm = SUBSTITUTE("&1&2DEFINE &3 PARAMETER DATASET FOR &4.",
+                                     CHR(10),
+                                     CHR(13),
+                                     ParameterType,
+                                     Name).
+        END.
+        RETURN parm.
+    END METHOD.
+    
+    METHOD OVERRIDE PUBLIC CHARACTER Generate():
+        DEFINE VARIABLE parm AS CHARACTER NO-UNDO.
+        
+        IF  TRIM(Name)          NE "" AND Name          NE ?
+        AND TRIM(ParameterType) NE "" AND ParameterType NE ? THEN
+        DO: 
+            ASSIGN parm = SUBSTITUTE("&1&2&3 DATASET FOR &4,",
+                                     CHR(10),
+                                     CHR(13),
+                                     ParameterType,
+                                     Name).
+        END.
+        RETURN parm.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Reflection/DataSetRelation.cls
+++ b/OEMock/Reflection/DataSetRelation.cls
@@ -1,0 +1,37 @@
+/*------------------------------------------------------------------------
+    File        : DataSetRelation
+    Purpose     : Represents a relation in a DataSet
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Reflection.DataSetRelation:
+    
+    DEFINE PUBLIC PROPERTY Name AS CHARACTER NO-UNDO 
+    GET.
+    PROTECTED SET.
+        
+    DEFINE PUBLIC PROPERTY ParentBufferName AS CHARACTER NO-UNDO 
+    GET.
+    PROTECTED SET.
+        
+    DEFINE PUBLIC PROPERTY ChildBufferName AS CHARACTER NO-UNDO 
+    GET.
+    PROTECTED SET.
+        
+    DEFINE PUBLIC PROPERTY RelationList AS CHARACTER NO-UNDO 
+    GET.
+    PROTECTED SET.
+		
+    CONSTRUCTOR PUBLIC DataSetRelation(INPUT nam AS CHARACTER):
+        SUPER().
+        
+        ASSIGN Name = nam.
+    END CONSTRUCTOR.
+
+	DESTRUCTOR PUBLIC DataSetRelation():
+	END DESTRUCTOR.
+
+END CLASS.

--- a/OEMock/Reflection/DataSetRelation.cls
+++ b/OEMock/Reflection/DataSetRelation.cls
@@ -15,15 +15,15 @@ CLASS OEMock.Reflection.DataSetRelation:
         
     DEFINE PUBLIC PROPERTY ParentBufferName AS CHARACTER NO-UNDO 
     GET.
-    PROTECTED SET.
+    SET.
         
     DEFINE PUBLIC PROPERTY ChildBufferName AS CHARACTER NO-UNDO 
     GET.
-    PROTECTED SET.
+    SET.
         
     DEFINE PUBLIC PROPERTY RelationList AS CHARACTER NO-UNDO 
     GET.
-    PROTECTED SET.
+    SET.
 		
     CONSTRUCTOR PUBLIC DataSetRelation(INPUT nam AS CHARACTER):
         SUPER().
@@ -33,5 +33,17 @@ CLASS OEMock.Reflection.DataSetRelation:
 
 	DESTRUCTOR PUBLIC DataSetRelation():
 	END DESTRUCTOR.
+	
+	METHOD PUBLIC LONGCHAR Generate():
+	    
+	    DEFINE VARIABLE res AS LONGCHAR NO-UNDO.
+	    
+	    ASSIGN res = "DATA-RELATION "
+	               + (IF Name NE "" AND Name NE ? THEN Name + " " ELSE "")
+	               + "FOR " + ParentBufferName + "," + ChildBufferName + " "
+	               + "RELATION-FIELDS (" + RelationList + ")".
+
+	    RETURN res.
+	END METHOD.
 
 END CLASS.

--- a/OEMock/Reflection/DataSetRelationList.cls
+++ b/OEMock/Reflection/DataSetRelationList.cls
@@ -1,0 +1,51 @@
+ /*------------------------------------------------------------------------
+    File        : DataSetRelationList
+    Purpose     : Holds list of DataSetRelation objects
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEMock.Reflection.DataSetRelation.
+USING OEMock.Util.BaseList.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Reflection.DataSetRelationList INHERITS BaseList: 
+
+	CONSTRUCTOR PUBLIC DataSetRelationList():
+		SUPER().
+	END CONSTRUCTOR.
+    
+    METHOD PUBLIC LOGICAL AddDataSetRelation(INPUT fil AS DataSetRelation):
+        RETURN SUPER:AddItem(fil).
+    END METHOD.
+    
+    METHOD OVERRIDE PUBLIC VOID EmptyList():
+        SUPER:EmptyList().
+    END METHOD.
+    
+    METHOD PROTECTED DataSetRelation CastToDataSetRelation(INPUT obj AS Progress.Lang.Object):
+        DEFINE VARIABLE res AS DataSetRelation NO-UNDO.
+        IF VALID-OBJECT(obj) AND obj:GetClass():IsA("OEMock.Reflection.DataSetRelation")THEN
+        DO:
+            res = DYNAMIC-CAST(obj, obj:GetClass():TypeName).
+        END.
+        RETURN res.
+    END METHOD.
+    
+    METHOD PUBLIC DataSetRelation MoveFirst():
+        RETURN CastToDataSetRelation(GetFirst()).
+    END METHOD.
+    
+    METHOD PUBLIC DataSetRelation MoveLast():
+        RETURN CastToDataSetRelation(GetLast()).
+    END METHOD.
+    
+    METHOD PUBLIC DataSetRelation MoveNext():
+        RETURN CastToDataSetRelation(GetNext()).
+    END METHOD.
+    
+    METHOD PUBLIC DataSetRelation MovePrev():
+        RETURN CastToDataSetRelation(GetPrev()).
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Reflection/ProcedureFile.cls
+++ b/OEMock/Reflection/ProcedureFile.cls
@@ -7,14 +7,19 @@ USING Progress.Lang.*.
 USING OEMock.Reflection.BaseFile.
 USING OEMock.Reflection.MethodList.
 USING OEMock.Generation.GeneratorList.
+USING OEMock.Reflection.DataSetList.
 
 ROUTINE-LEVEL ON ERROR UNDO, THROW.
 
 CLASS OEMock.Reflection.ProcedureFile INHERITS BaseFile: 
 
-	DEFINE PUBLIC PROPERTY Functions AS OEMock.Reflection.MethodList NO-UNDO 
+	DEFINE PUBLIC PROPERTY DataSets AS OEMock.Reflection.DataSetList NO-UNDO 
 	GET.
 	PROTECTED SET. 
+
+    DEFINE PUBLIC PROPERTY Functions AS OEMock.Reflection.MethodList NO-UNDO 
+    GET.
+    PROTECTED SET. 
 
     DEFINE PUBLIC PROPERTY Generators AS OEMock.Generation.GeneratorList NO-UNDO 
     GET.
@@ -28,12 +33,14 @@ CLASS OEMock.Reflection.ProcedureFile INHERITS BaseFile:
 		SUPER(INPUT fname).
 		
 		/* Create objects */
+		DataSets   = NEW DataSetList().
 		Functions  = NEW MethodList().
 		Procedures = NEW MethodList().
 		Generators = NEW GeneratorList().
 	END CONSTRUCTOR.
 
 	DESTRUCTOR PUBLIC ProcedureFile():
+        IF VALID-OBJECT(DataSets)   THEN DELETE OBJECT DataSets.
 	    IF VALID-OBJECT(Functions)  THEN DELETE OBJECT Functions.
 	    IF VALID-OBJECT(Procedures) THEN DELETE OBJECT Procedures.
         IF VALID-OBJECT(Generators) THEN DELETE OBJECT Generators.
@@ -42,9 +49,10 @@ CLASS OEMock.Reflection.ProcedureFile INHERITS BaseFile:
 	METHOD OVERRIDE PUBLIC LONGCHAR Generate():
 	    DEFINE VARIABLE res AS LONGCHAR NO-UNDO.
 	    
-	    ASSIGN res = SUBSTITUTE("&1&2&1&3&1&4&1&5&1&6",
+	    ASSIGN res = SUBSTITUTE("&1&2&1&3&1&4&1&5&1&6&1&7",
 	                            CHR(10) + CHR(13),
 	                            GenerateUsing(),
+	                            GenerateDataSets(),
 	                            GenerateFunctionForwards(),
 	                            Generators:GenerateProcedural(),
                                 GenerateProcedures(),
@@ -52,6 +60,24 @@ CLASS OEMock.Reflection.ProcedureFile INHERITS BaseFile:
 
         RETURN res.
 	END METHOD.
+    
+    METHOD PROTECTED LONGCHAR GenerateDataSets():
+        DEFINE VARIABLE res  AS LONGCHAR NO-UNDO.
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        
+        /* Loop through datasets */
+        dset = DataSets:MoveFirst().
+        DO WHILE VALID-OBJECT(dset):
+            ASSIGN res  = res + dset:Generate()
+                        + CHR(10) + CHR(13)
+                   dset = DataSets:MoveNext().
+        END.
+        
+        /* Sanity check output */
+        IF res = ? THEN res = "".
+
+        RETURN res.
+    END METHOD.
 	
 	METHOD PROTECTED LONGCHAR GenerateFunctionForwards():
 	    DEFINE VARIABLE res  AS LONGCHAR NO-UNDO.

--- a/OEMock/Tests/Inspection/ProcedureInspectorTester.cls
+++ b/OEMock/Tests/Inspection/ProcedureInspectorTester.cls
@@ -89,5 +89,31 @@ CLASS OEMock.Tests.Inspection.ProcedureInspectorTester:
         IF VALID-OBJECT(base) THEN DELETE OBJECT base.
         IF VALID-OBJECT(proc) THEN DELETE OBJECT proc.
     END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID InspectReturnsClassWithDataSets():
+        DEFINE VARIABLE insp AS ProcedureInspector NO-UNDO.
+        DEFINE VARIABLE base AS BaseFile           NO-UNDO.
+        DEFINE VARIABLE proc AS ProcedureFile      NO-UNDO.
+        
+        insp = NEW ProcedureInspector("OEMock/Tests/Inspection/TestProcedure.p").
+        base = insp:Inspect().
+        
+        Assert:IsTrue(VALID-OBJECT(base), "Invalid object returned").
+        
+        IF base:GetClass():IsA("OEMock.Reflection.ProcedureFile") THEN
+        DO:
+            proc = DYNAMIC-CAST(base, base:GetClass():TypeName).
+            Assert:IsTrue(proc:DataSets:Count > 0).
+        END.
+        ELSE
+        DO:
+            Assert:Fail("Incompatible object type returned").
+        END.
+        
+        IF VALID-OBJECT(insp) THEN DELETE OBJECT insp.
+        IF VALID-OBJECT(base) THEN DELETE OBJECT base.
+        IF VALID-OBJECT(proc) THEN DELETE OBJECT proc.
+    END METHOD.
 
 END CLASS.

--- a/OEMock/Tests/Inspection/TestProcedure.p
+++ b/OEMock/Tests/Inspection/TestProcedure.p
@@ -8,6 +8,21 @@
 
 ROUTINE-LEVEL ON ERROR UNDO, THROW.
 
+DEFINE TEMP-TABLE ttTempTable NO-UNDO
+    FIELD KeyField AS INTEGER
+    INDEX PriKey IS PRIMARY UNIQUE KeyField ASCENDING.
+    
+DEFINE TEMP-TABLE ttChildTable NO-UNDO
+    FIELD KeyField AS INTEGER
+    FIELD ChildField AS CHARACTER
+    FIELD DataField  AS CHARACTER
+    INDEX PriKey IS PRIMARY UNIQUE KeyField ASCENDING ChildField ASCENDING.
+    
+DEFINE DATASET dsTempData
+    FOR ttTempTable, ttChildTable
+    DATA-RELATION FOR ttTempTable, ttChildTable
+        RELATION-FIELDS(KeyField,KeyField).
+
 /* ********************  Preprocessor Definitions  ******************** */
 
 /* ************************  Function Prototypes ********************** */

--- a/OEMock/Tests/Reflection/AllTests.cls
+++ b/OEMock/Tests/Reflection/AllTests.cls
@@ -24,6 +24,7 @@ CLASS OEMock.Tests.Reflection.AllTests INHERITS TestSuite:
     AddTest(NEW MethodListTester()).
     AddTest(NEW DataSetRelationTester()).
     AddTest(NEW DataSetRelationListTester()).
+    AddTest(NEW DataSetTester()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/AllTests.cls
+++ b/OEMock/Tests/Reflection/AllTests.cls
@@ -26,6 +26,7 @@ CLASS OEMock.Tests.Reflection.AllTests INHERITS TestSuite:
     AddTest(NEW DataSetRelationListTester()).
     AddTest(NEW DataSetTester()).
     AddTest(NEW DataSetListTester()).
+    AddTest(NEW DataSetParameterTester()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/AllTests.cls
+++ b/OEMock/Tests/Reflection/AllTests.cls
@@ -22,6 +22,7 @@ CLASS OEMock.Tests.Reflection.AllTests INHERITS TestSuite:
     AddTest(NEW ProcedureFileTester()).
     AddTest(NEW ClassFileTester()).
     AddTest(NEW MethodListTester()).
+    AddTest(NEW DataSetRelationTester()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/AllTests.cls
+++ b/OEMock/Tests/Reflection/AllTests.cls
@@ -25,6 +25,7 @@ CLASS OEMock.Tests.Reflection.AllTests INHERITS TestSuite:
     AddTest(NEW DataSetRelationTester()).
     AddTest(NEW DataSetRelationListTester()).
     AddTest(NEW DataSetTester()).
+    AddTest(NEW DataSetListTester()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/AllTests.cls
+++ b/OEMock/Tests/Reflection/AllTests.cls
@@ -23,6 +23,7 @@ CLASS OEMock.Tests.Reflection.AllTests INHERITS TestSuite:
     AddTest(NEW ClassFileTester()).
     AddTest(NEW MethodListTester()).
     AddTest(NEW DataSetRelationTester()).
+    AddTest(NEW DataSetRelationListTester()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/ClassFileTester.cls
+++ b/OEMock/Tests/Reflection/ClassFileTester.cls
@@ -67,6 +67,17 @@ CLASS OEMock.Tests.Reflection.ClassFileTester:
     END METHOD.
     
     @Test.
+    METHOD PUBLIC VOID ConstructorCreatesDataSetsList():
+        DEFINE VARIABLE clsfile AS ClassFile NO-UNDO.
+        
+        clsfile = NEW ClassFile("FileName", "OEMock.Tests.Util.ListObject").
+        
+        Assert:IsTrue(VALID-OBJECT(clsfile:DataSets)).
+        
+        IF VALID-OBJECT(clsfile) THEN DELETE OBJECT clsfile.
+    END METHOD.
+    
+    @Test.
     METHOD PUBLIC VOID ConstructorSetsTypeName():
         DEFINE VARIABLE clsfile AS ClassFile NO-UNDO.
         
@@ -194,6 +205,20 @@ CLASS OEMock.Tests.Reflection.ClassFileTester:
         AssertString:Contains(clsCode, 
                               "END CLASS.").
                               
+        IF VALID-OBJECT(clsfile) THEN DELETE OBJECT clsfile.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesDataSets():
+        DEFINE VARIABLE clsfile AS ClassFile NO-UNDO.
+        DEFINE VARIABLE outp    AS LONGCHAR  NO-UNDO.
+        
+        clsfile = NEW ClassFile("FileName", "OEMock.Tests.Util.ListObject").
+        clsfile:DataSets:AddDataSet(NEW OEMock.Reflection.DataSet('dsName')).
+        
+        outp = clsfile:Generate().
+        AssertString:Contains(outp, "DEFINE DATASET dsName"). 
+        
         IF VALID-OBJECT(clsfile) THEN DELETE OBJECT clsfile.
     END METHOD.
     

--- a/OEMock/Tests/Reflection/DataSetListTester.cls
+++ b/OEMock/Tests/Reflection/DataSetListTester.cls
@@ -1,0 +1,185 @@
+/*------------------------------------------------------------------------
+    File        : DataSetListTester
+    Purpose     : 
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEUnit.Assertion.*.
+USING OEMock.Reflection.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Tests.Reflection.DataSetListTester:
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsDestroyOnDestructToTrue():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetList().
+        Assert:IsTrue(list:DestroyOnDestruct).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorCreatesBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetList().
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID AddDataSetIncrementsCounter():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        DEFINE VARIABLE drel AS DataSet NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetList().
+        drel = NEW DataSet("DataSetName").
+        list:AddDataSet(drel).
+        Assert:AreEqual(list:Count,1).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID AddItemDoesNotIncrementCounterWhenNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetList().
+        list:AddDataSet(?).
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID EmptyListClearsList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        DEFINE VARIABLE drel AS DataSet NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetList().
+        drel = NEW DataSet("DataSetName").
+        list:AddDataSet(drel).
+        Assert:AreEqual(list:Count,1).
+        list:EmptyList().
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveFirstIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        DEFINE VARIABLE drel AS DataSet NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetList().
+        drel = NEW DataSet("DataSetName").
+        list:AddDataSet(drel).
+        Assert:IsNotNull(list:MoveFirst()).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveFirstIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        DEFINE VARIABLE drel AS DataSet NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetList().
+        drel = NEW DataSet("DataSetName").
+        Assert:IsNull(list:MoveFirst()).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveLastIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        DEFINE VARIABLE meth AS DataSet NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetList().
+        meth = NEW DataSet("DataSetName").
+        list:AddDataSet(meth).
+        Assert:IsNotNull(list:MoveLast()).
+        IF VALID-OBJECT(meth) THEN DELETE OBJECT meth.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveLastIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        DEFINE VARIABLE meth AS DataSet NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetList().
+        meth = NEW DataSet("DataSetName").
+        Assert:IsNull(list:MoveLast()).
+        IF VALID-OBJECT(meth) THEN DELETE OBJECT meth.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        DEFINE VARIABLE meth AS DataSet NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetList().
+        meth = NEW DataSet("DataSetName").
+        list:AddDataSet(meth).
+        Assert:IsNotNull(list:MoveNext()).
+        IF VALID-OBJECT(meth) THEN DELETE OBJECT meth.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        DEFINE VARIABLE meth AS DataSet NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetList().
+        meth = NEW DataSet("DataSetName").
+        Assert:IsNull(list:MoveNext()).
+        IF VALID-OBJECT(meth) THEN DELETE OBJECT meth.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextReturnsValidObjectsWithMultipleItemList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        DEFINE VARIABLE res  AS DataSet NO-UNDO.
+        
+        list = NEW OEMock.Reflection.DataSetList().
+        list:AddDataSet(NEW DataSet('Relation1')).
+        list:AddDataSet(NEW DataSet('Relation2')).
+        list:AddDataSet(NEW DataSet('Relation3')).
+
+        res = list:MoveFirst().
+        AssertString:Contains(res:GetClass():TypeName, 'DataSet').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.DataSet')).
+        Assert:AreEqual(res:Name, "Relation1").
+
+        res = list:MoveNext().
+        AssertString:Contains(res:GetClass():TypeName, 'DataSet').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.DataSet')).
+        Assert:AreEqual(res:Name, "Relation2").
+
+        res = list:MoveNext().
+        AssertString:Contains(res:GetClass():TypeName, 'DataSet').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.DataSet')).
+        Assert:AreEqual(res:Name, "Relation3").
+        
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MovePrevIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        DEFINE VARIABLE meth AS DataSet NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetList().
+        meth = NEW DataSet("DataSetName").
+        list:AddDataSet(meth).
+        Assert:IsNotNull(list:MovePrev()).
+        IF VALID-OBJECT(meth) THEN DELETE OBJECT meth.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MovePrevIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetList NO-UNDO.
+        DEFINE VARIABLE meth AS DataSet NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetList().
+        meth = NEW DataSet("DataSetName").
+        Assert:IsNull(list:MovePrev()).
+        IF VALID-OBJECT(meth) THEN DELETE OBJECT meth.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/Reflection/DataSetParameterTester.cls
+++ b/OEMock/Tests/Reflection/DataSetParameterTester.cls
@@ -1,0 +1,164 @@
+/*------------------------------------------------------------------------
+    File        : DataSetParameterTester
+    Purpose     : 
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEUnit.Assertion.*.
+USING OEMock.Reflection.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Tests.Reflection.DataSetParameterTester:
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsName():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter('DataSetName').
+        
+        Assert:AreEqual(parm:Name, 'DataSetName').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD. 
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsParameterTypeToInput():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter('DataSetName').
+        
+        Assert:AreEqual(parm:ParameterType, 'INPUT').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateDefinitionReturnsValidDefinition():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter('DataSetName').
+        
+        Assert:AreEqual(parm:GenerateDefinition(), CHR(10) + CHR(13) + 'DEFINE INPUT PARAMETER DATASET FOR DataSetName.').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateDefinitionObservesParameterType():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter('DataSetName').
+        parm:ParameterType = "OUTPUT".
+        Assert:AreEqual(parm:GenerateDefinition(), CHR(10) + CHR(13) + 'DEFINE OUTPUT PARAMETER DATASET FOR DataSetName.').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateDefinitionReturnsBlankWithBlankName():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter('').
+        Assert:AreEqual(parm:GenerateDefinition(), '').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateDefinitionReturnsBlankWithNullName():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter(?).
+        Assert:AreEqual(parm:GenerateDefinition(), '').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateDefinitionReturnsBlankWithBlankParameterType():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter('DataSetName').
+        parm:ParameterType = ''.
+        Assert:AreEqual(parm:GenerateDefinition(), '').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateDefinitionReturnsBlankWithNullParameterType():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter('DataSetName').
+        parm:ParameterType = ?.
+        Assert:AreEqual(parm:GenerateDefinition(), '').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateReturnsValidDefinition():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter('DataSetName').
+        
+        Assert:AreEqual(parm:Generate(), CHR(10) + CHR(13) + 'INPUT DATASET FOR DataSetName,').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesParameterType():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter('DataSetName').
+        parm:ParameterType = "OUTPUT".
+        Assert:AreEqual(parm:Generate(), CHR(10) + CHR(13) + 'OUTPUT DATASET FOR DataSetName,').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateReturnsBlankWithBlankName():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter('').
+        Assert:AreEqual(parm:Generate(), '').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateReturnsBlankWithNullName():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter(?).
+        Assert:AreEqual(parm:Generate(), '').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateReturnsBlankWithBlankParameterType():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter('DataSetName').
+        parm:ParameterType = ''.
+        Assert:AreEqual(parm:Generate(), '').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateReturnsBlankWithNullParameterType():
+        DEFINE VARIABLE parm AS DataSetParameter NO-UNDO.
+        
+        parm = NEW DataSetParameter('DataSetName').
+        parm:ParameterType = ?.
+        Assert:AreEqual(parm:Generate(), '').
+        
+        IF VALID-OBJECT(parm) THEN DELETE OBJECT parm.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/Reflection/DataSetRelationListTester.cls
+++ b/OEMock/Tests/Reflection/DataSetRelationListTester.cls
@@ -1,0 +1,185 @@
+/*------------------------------------------------------------------------
+    File        : DataSetRelationListTester
+    Purpose     : 
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEUnit.Assertion.*.
+USING OEMock.Reflection.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Tests.Reflection.DataSetRelationListTester:
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsDestroyOnDestructToTrue():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        Assert:IsTrue(list:DestroyOnDestruct).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorCreatesBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID AddDataSetRelationIncrementsCounter():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        DEFINE VARIABLE drel AS DataSetRelation NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        drel = NEW DataSetRelation("Relation").
+        list:AddDataSetRelation(drel).
+        Assert:AreEqual(list:Count,1).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID AddItemDoesNotIncrementCounterWhenNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        list:AddDataSetRelation(?).
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID EmptyListClearsList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        DEFINE VARIABLE drel AS DataSetRelation NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        drel = NEW DataSetRelation("Relation").
+        list:AddDataSetRelation(drel).
+        Assert:AreEqual(list:Count,1).
+        list:EmptyList().
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveFirstIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        DEFINE VARIABLE drel AS DataSetRelation NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        drel = NEW DataSetRelation("Relation").
+        list:AddDataSetRelation(drel).
+        Assert:IsNotNull(list:MoveFirst()).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveFirstIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        DEFINE VARIABLE drel AS DataSetRelation NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        drel = NEW DataSetRelation("Relation").
+        Assert:IsNull(list:MoveFirst()).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveLastIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        DEFINE VARIABLE meth AS DataSetRelation NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        meth = NEW DataSetRelation("Relation").
+        list:AddDataSetRelation(meth).
+        Assert:IsNotNull(list:MoveLast()).
+        IF VALID-OBJECT(meth) THEN DELETE OBJECT meth.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveLastIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        DEFINE VARIABLE meth AS DataSetRelation NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        meth = NEW DataSetRelation("Relation").
+        Assert:IsNull(list:MoveLast()).
+        IF VALID-OBJECT(meth) THEN DELETE OBJECT meth.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        DEFINE VARIABLE meth AS DataSetRelation NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        meth = NEW DataSetRelation("Relation").
+        list:AddDataSetRelation(meth).
+        Assert:IsNotNull(list:MoveNext()).
+        IF VALID-OBJECT(meth) THEN DELETE OBJECT meth.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        DEFINE VARIABLE meth AS DataSetRelation NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        meth = NEW DataSetRelation("Relation").
+        Assert:IsNull(list:MoveNext()).
+        IF VALID-OBJECT(meth) THEN DELETE OBJECT meth.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextReturnsValidObjectsWithMultipleItemList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        DEFINE VARIABLE res  AS DataSetRelation NO-UNDO.
+        
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        list:AddDataSetRelation(NEW DataSetRelation('Relation1')).
+        list:AddDataSetRelation(NEW DataSetRelation('Relation2')).
+        list:AddDataSetRelation(NEW DataSetRelation('Relation3')).
+
+        res = list:MoveFirst().
+        AssertString:Contains(res:GetClass():TypeName, 'DataSetRelation').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.DataSetRelation')).
+        Assert:AreEqual(res:Name, "Relation1").
+
+        res = list:MoveNext().
+        AssertString:Contains(res:GetClass():TypeName, 'DataSetRelation').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.DataSetRelation')).
+        Assert:AreEqual(res:Name, "Relation2").
+
+        res = list:MoveNext().
+        AssertString:Contains(res:GetClass():TypeName, 'DataSetRelation').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.DataSetRelation')).
+        Assert:AreEqual(res:Name, "Relation3").
+        
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MovePrevIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        DEFINE VARIABLE meth AS DataSetRelation NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        meth = NEW DataSetRelation("Relation").
+        list:AddDataSetRelation(meth).
+        Assert:IsNotNull(list:MovePrev()).
+        IF VALID-OBJECT(meth) THEN DELETE OBJECT meth.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MovePrevIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.DataSetRelationList NO-UNDO.
+        DEFINE VARIABLE meth AS DataSetRelation NO-UNDO.
+        list = NEW OEMock.Reflection.DataSetRelationList().
+        meth = NEW DataSetRelation("Relation").
+        Assert:IsNull(list:MovePrev()).
+        IF VALID-OBJECT(meth) THEN DELETE OBJECT meth.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/Reflection/DataSetRelationTester.cls
+++ b/OEMock/Tests/Reflection/DataSetRelationTester.cls
@@ -1,0 +1,26 @@
+ /*------------------------------------------------------------------------
+    File        : DataSetRelationTester
+    Purpose     : Unit tests for DataSet class
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEUnit.Assertion.*.
+USING OEMock.Reflection.DataSetRelation.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Tests.Reflection.DataSetRelationTester:
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsName():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSetRelation NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSetRelation("dsName").
+        
+        Assert:AreEqual(dset:Name, "dsName").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/Reflection/DataSetRelationTester.cls
+++ b/OEMock/Tests/Reflection/DataSetRelationTester.cls
@@ -22,5 +22,122 @@ CLASS OEMock.Tests.Reflection.DataSetRelationTester:
         
         IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
     END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateCreatesBasicRelation():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSetRelation NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSetRelation("dsName").
+        
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, "DATA-RELATION").
+        AssertString:Contains(gen, "FOR").
+        AssertString:Contains(gen, "RELATION-FIELDS").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+        
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateIncludesName():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSetRelation NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSetRelation("dsName").
+        
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, "DATA-RELATION dsName ").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+        
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateIgnoresBlankName():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSetRelation NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSetRelation("").
+        
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, "DATA-RELATION FOR ").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+        
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateIgnoresNullName():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSetRelation NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSetRelation(?).
+        
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, "DATA-RELATION FOR ").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+        
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateIncludesParentBuffer():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSetRelation NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSetRelation("dsName").
+        dset:ParentBufferName = "ParentBuffer".
+        
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, "FOR ParentBuffer,").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+        
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateIncludesChildBuffer():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSetRelation NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSetRelation("dsName").
+        dset:ChildBufferName = "ChildBuffer".
+        
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, ",ChildBuffer").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+        
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateIncludesRelationList():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSetRelation NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSetRelation("dsName").
+        dset:RelationList = "FieldA,FieldB".
+        
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, "RELATION-FIELDS (FieldA,FieldB)").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+        
+    END METHOD.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/DataSetTester.cls
+++ b/OEMock/Tests/Reflection/DataSetTester.cls
@@ -1,0 +1,108 @@
+ /*------------------------------------------------------------------------
+    File        : DataSetTester
+    Purpose     : Unit tests for DataSet class
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEUnit.Assertion.*.
+USING OEMock.Reflection.DataSet.
+USING OEMock.Reflection.DataSetRelation.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Tests.Reflection.DataSetTester:
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsName():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        
+        Assert:AreEqual(dset:Name, "dsName").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorCreatesDataSetRelations():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        
+        Assert:IsTrue(VALID-OBJECT(dset:DataSetRelations)).
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateDefinesBasicDataset():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, "DEFINE DATASET ").
+        AssertString:Contains(gen, " FOR ").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateIncludesName():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, "DEFINE DATASET dsName FOR ").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateIncludesBuffers():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        dset:Buffers = "TableA,TableB".
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, " FOR TableA,TableB ").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateIncludesRelations():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet         NO-UNDO.
+        DEFINE VARIABLE drel AS OEMock.Reflection.DataSetRelation NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                          NO-UNDO.
+        
+        drel = NEW DataSetRelation("Relation1").
+        drel:ParentBufferName = "TableA".
+        drel:ChildBufferName  = "TableB".
+        drel:RelationList = "FieldA,FieldA".
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        dset:Buffers = "TableA,TableB".
+        dset:DataSetRelations:AddDataSetRelation(drel).
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, STRING(drel:Generate())).
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/Reflection/DataSetTester.cls
+++ b/OEMock/Tests/Reflection/DataSetTester.cls
@@ -25,6 +25,18 @@ CLASS OEMock.Tests.Reflection.DataSetTester:
     END METHOD.
     
     @Test.
+    METHOD PUBLIC VOID ConstructorSetsNotStatic():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        
+        Assert:IsFalse(dset:Static).
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+    
+    @Test.
     METHOD PUBLIC VOID ConstructorCreatesDataSetRelations():
         
         DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
@@ -48,6 +60,22 @@ CLASS OEMock.Tests.Reflection.DataSetTester:
         
         AssertString:Contains(gen, "DEFINE DATASET ").
         AssertString:Contains(gen, " FOR ").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesStatic():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        dset:Static = TRUE.
+        
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, "DEFINE STATIC DATASET dsName FOR ").
         
         IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
     END METHOD.

--- a/OEMock/Tests/Reflection/DataSetTester.cls
+++ b/OEMock/Tests/Reflection/DataSetTester.cls
@@ -25,6 +25,42 @@ CLASS OEMock.Tests.Reflection.DataSetTester:
     END METHOD.
     
     @Test.
+    METHOD PUBLIC VOID ConstructorSetsBlankNamespacePrefix():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        
+        Assert:AreEqual(dset:NamespacePrefix, "").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsBlankNamespaceURI():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        
+        Assert:AreEqual(dset:NamespaceURI, "").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsNotReference():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        
+        Assert:IsFalse(dset:Reference).
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+    
+    @Test.
     METHOD PUBLIC VOID ConstructorSetsNotStatic():
         
         DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
@@ -106,6 +142,54 @@ CLASS OEMock.Tests.Reflection.DataSetTester:
         gen = dset:Generate().
         
         AssertString:Contains(gen, " FOR TableA,TableB ").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesNamespacePrefix():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        dset:NamespacePrefix = "MyNameSpacePrefix".
+        
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, " NAMESPACE-PREFIX ~"MyNameSpacePrefix~" ").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesNamespaceURI():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        dset:NamespaceURI = "MyNameSpaceURI".
+        
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, " NAMESPACE-URI ~"MyNameSpaceURI~" ").
+        
+        IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesReference():
+        
+        DEFINE VARIABLE dset AS OEMock.Reflection.DataSet NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        dset = NEW OEMock.Reflection.DataSet("dsName").
+        dset:Reference = TRUE.
+        
+        gen = dset:Generate().
+        
+        AssertString:Contains(gen, " REFERENCE-ONLY ").
         
         IF VALID-OBJECT(dset) THEN DELETE OBJECT dset.
     END METHOD.

--- a/OEMock/Tests/Reflection/ProcedureFileTester.cls
+++ b/OEMock/Tests/Reflection/ProcedureFileTester.cls
@@ -12,6 +12,17 @@ ROUTINE-LEVEL ON ERROR UNDO, THROW.
 CLASS OEMock.Tests.Reflection.ProcedureFileTester: 
     
     @Test.
+    METHOD PUBLIC VOID ConstructorCreatesDataSetList():
+        DEFINE VARIABLE procfile AS ProcedureFile NO-UNDO.
+        
+        procfile = NEW ProcedureFile("FileName").
+        
+        Assert:IsTrue(VALID-OBJECT(procfile:DataSets)).
+        
+        IF VALID-OBJECT(procfile) THEN DELETE OBJECT procfile.
+    END METHOD.
+    
+    @Test.
     METHOD PUBLIC VOID ConstructorCreatesFunctionList():
         DEFINE VARIABLE procfile AS ProcedureFile NO-UNDO.
         
@@ -116,6 +127,20 @@ CLASS OEMock.Tests.Reflection.ProcedureFileTester:
                               STRING(procFile:Generate())).
         
         IF VALID-OBJECT(procFile) THEN DELETE OBJECT procFile.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesDataSets():
+        DEFINE VARIABLE procfile AS ProcedureFile NO-UNDO.
+        DEFINE VARIABLE outp     AS LONGCHAR NO-UNDO.
+        
+        procfile = NEW ProcedureFile("FileName").
+        procfile:DataSets:AddDataSet(NEW OEMock.Reflection.DataSet('dsName')).
+        
+        outp = procfile:Generate().
+        AssertString:Contains(outp, "DEFINE DATASET dsName"). 
+        
+        IF VALID-OBJECT(procfile) THEN DELETE OBJECT procfile.
     END METHOD.
     
     @Test.


### PR DESCRIPTION
Fixes #3.

DataSets are now detected when analysing a file, and are generated when a test double is created. DataSet parameters are also supported.
