### PR TITLE
Allow temp-tables to be defined inside of test doubles

### DIFF
--- a/OEMock/BaseDouble.cls
+++ b/OEMock/BaseDouble.cls
@@ -176,5 +176,84 @@ CLASS OEMock.BaseDouble:
         
         AddProcedureParameter(parm).
     END METHOD.
+    
+    METHOD PUBLIC VOID AddTempTable(INPUT ttHandle AS HANDLE):
+        
+        DEFINE VARIABLE ttObject   AS OEMock.Reflection.TempTable NO-UNDO.
+        DEFINE VARIABLE ttField    AS OEMock.Reflection.TempTableField NO-UNDO.
+        DEFINE VARIABLE ttIndex    AS OEMock.Reflection.TempTableIndex NO-UNDO.
+        DEFINE VARIABLE ttIdxField AS OEMock.Reflection.TempTableIndexField NO-UNDO.
+        DEFINE VARIABLE ttBuffer   AS HANDLE    NO-UNDO.
+        DEFINE VARIABLE fieldLoop  AS INTEGER   NO-UNDO.
+        DEFINE VARIABLE bufField   AS HANDLE    NO-UNDO.
+        DEFINE VARIABLE indexLoop  AS INTEGER   NO-UNDO.
+        DEFINE VARIABLE indexData  AS CHARACTER NO-UNDO.
+        DEFINE VARIABLE idxField   AS INTEGER   NO-UNDO.
+        
+        IF NOT VALID-HANDLE(ttHandle) THEN RETURN.
+        
+        /* Set properties on object, and fetch buffer handle */
+        ASSIGN ttObject                 = NEW OEMock.Reflection.TempTable(INPUT ttHandle:NAME)
+               ttObject:NamespacePrefix = ttHandle:NAMESPACE-PREFIX
+               ttObject:NamespaceURI    = ttHandle:NAMESPACE-URI
+               ttObject:NoUndo          = NOT(ttHandle:UNDO)
+               ttBuffer                 = ttHandle:DEFAULT-BUFFER-HANDLE.
+               
+        /* Loop through buffer information to create field list */
+        DO fieldLoop = 1 TO ttBuffer:NUM-FIELDS:
+            
+            ASSIGN bufField = ttBuffer:BUFFER-FIELD(fieldLoop)
+                   ttField  = NEW OEMock.Reflection.TempTableField(INPUT bufField:NAME, INPUT bufField:DATA-TYPE).
+                   
+            /* Set temp-table field properties */
+            ASSIGN ttField:Extent          = bufField:EXTENT
+                   ttField:Initial         = bufField:INITIAL
+                   ttField:SerializeHidden = bufField:SERIALIZE-HIDDEN
+                   ttField:SerializeName   = bufField:SERIALIZE-NAME
+                   ttField:XMLDataType     = bufField:XML-DATA-TYPE
+                   ttField:XMLNodeType     = bufField:XML-NODE-TYPE
+                   ttField:XMLNodeName     = bufField:XML-NODE-NAME.
+
+            ttObject:Fields:AddTempTableField(ttField).
+        END.
+        
+        /* Loop through index information */
+        ASSIGN indexLoop = 1
+               indexData = ttBuffer:INDEX-INFORMATION(indexLoop).
+        
+        indexLoop:
+        DO WHILE(indexData NE ?):
+            
+            /* If the name of the index is 'default' and there are only 5 entries in the list, then
+             * this is the default index, and there were no explicit indexes added to the temp-table
+             */
+            IF ENTRY(1, indexData) = "default" AND NUM-ENTRIES(indexData) = 5 THEN LEAVE indexLoop.
+
+            ASSIGN ttIndex           = NEW OEMock.Reflection.TempTableIndex(ENTRY(1, indexData))
+                   ttIndex:Unique    = (ENTRY(2,indexData) = "1")
+                   ttIndex:Primary   = (ENTRY(3,indexData) = "1")
+                   ttIndex:WordIndex = (ENTRY(4,indexData) = "1").
+            
+            /* Remaining data is field list, following by 0 for ascending, 1 for descending */
+            ASSIGN idxField = 5.
+            indexFieldLoop:
+            DO WHILE(idxField <= NUM-ENTRIES(indexData)):
+                
+                ASSIGN ttIdxField = NEW OEMock.Reflection.TempTableIndexField(ENTRY(idxField, indexData))
+                       ttIdxField:Descending = (ENTRY(idxField + 1, indexData) = "1")
+                       idxField = idxField + 2.
+                       
+                ttIndex:Fields:AddTempTableIndexField(ttIdxField).
+            END.
+            
+            ttObject:Indexes:AddTempTableIndex(ttIndex).
+        
+            ASSIGN indexLoop = indexLoop + 1
+                   indexData = ttBuffer:INDEX-INFORMATION(indexLoop).
+        END.
+        
+        THIS-OBJECT:File:TempTables:AddTempTable(INPUT ttObject).
+               
+    END METHOD.
 
 END CLASS.

--- a/OEMock/Reflection/BaseFile.cls
+++ b/OEMock/Reflection/BaseFile.cls
@@ -5,6 +5,7 @@
 
 USING Progress.Lang.*.
 USING OEMock.Util.StringList.
+USING OEMock.Reflection.TempTableList.
 
 ROUTINE-LEVEL ON ERROR UNDO, THROW.
 
@@ -20,16 +21,22 @@ CLASS OEMock.Reflection.BaseFile:
 
     DEFINE PUBLIC PROPERTY UsingList AS OEMock.Util.StringList NO-UNDO 
     GET.
+    PROTECTED SET.  
+
+    DEFINE PUBLIC PROPERTY TempTables AS OEMock.Reflection.TempTableList NO-UNDO 
+    GET.
     PROTECTED SET. 
 	
 	CONSTRUCTOR BaseFile(INPUT fname AS CHARACTER):
 	    SUPER().
 	    ASSIGN FileName  = fname.
                UsingList = NEW StringList(). 
+               TempTables = NEW TempTableList().
     END CONSTRUCTOR. 
     
     DESTRUCTOR BaseFile():
         IF VALID-OBJECT(UsingList) THEN DELETE OBJECT UsingList.
+        IF VALID-OBJECT(TempTables) THEN DELETE OBJECT TempTables.
     END DESTRUCTOR.
     
     METHOD PUBLIC LONGCHAR Generate():

--- a/OEMock/Reflection/ClassFile.cls
+++ b/OEMock/Reflection/ClassFile.cls
@@ -9,7 +9,6 @@ USING OEMock.Reflection.MethodList.
 USING OEMock.Generation.GeneratorList.
 USING OEMock.Util.StringList.
 USING OEMock.Reflection.DataSetList.
-USING OEMock.Reflection.TempTableList.
 
 ROUTINE-LEVEL ON ERROR UNDO, THROW.
 
@@ -51,10 +50,6 @@ CLASS OEMock.Reflection.ClassFile INHERITS BaseFile:
             RETURN ?.
     END GET.
 
-    DEFINE PUBLIC PROPERTY TempTables AS OEMock.Reflection.TempTableList NO-UNDO 
-    GET.
-    PROTECTED SET. 
-
     DEFINE PUBLIC PROPERTY TypeName AS CHARACTER NO-UNDO 
     GET():
         IF VALID-OBJECT(ClassRef) THEN
@@ -75,7 +70,6 @@ CLASS OEMock.Reflection.ClassFile INHERITS BaseFile:
         Generators   = NEW GeneratorList().
         Interfaces   = NEW StringList().
         DataSets     = NEW DataSetList().
-        TempTables   = NEW TempTableList().
              
     END CONSTRUCTOR.
 
@@ -86,7 +80,6 @@ CLASS OEMock.Reflection.ClassFile INHERITS BaseFile:
         IF VALID-OBJECT(Generators)   THEN DELETE OBJECT Generators.
         IF VALID-OBJECT(Interfaces)   THEN DELETE OBJECT Interfaces.
         IF VALID-OBJECT(DataSets)     THEN DELETE OBJECT DataSets.
-        IF VALID-OBJECT(TempTables)   THEN DELETE OBJECT TempTables.
     END DESTRUCTOR.
     
     METHOD PROTECTED LONGCHAR GenerateClass():

--- a/OEMock/Reflection/ClassFile.cls
+++ b/OEMock/Reflection/ClassFile.cls
@@ -9,6 +9,7 @@ USING OEMock.Reflection.MethodList.
 USING OEMock.Generation.GeneratorList.
 USING OEMock.Util.StringList.
 USING OEMock.Reflection.DataSetList.
+USING OEMock.Reflection.TempTableList.
 
 ROUTINE-LEVEL ON ERROR UNDO, THROW.
 
@@ -50,6 +51,10 @@ CLASS OEMock.Reflection.ClassFile INHERITS BaseFile:
             RETURN ?.
     END GET.
 
+    DEFINE PUBLIC PROPERTY TempTables AS OEMock.Reflection.TempTableList NO-UNDO 
+    GET.
+    PROTECTED SET. 
+
     DEFINE PUBLIC PROPERTY TypeName AS CHARACTER NO-UNDO 
     GET():
         IF VALID-OBJECT(ClassRef) THEN
@@ -70,6 +75,7 @@ CLASS OEMock.Reflection.ClassFile INHERITS BaseFile:
         Generators   = NEW GeneratorList().
         Interfaces   = NEW StringList().
         DataSets     = NEW DataSetList().
+        TempTables   = NEW TempTableList().
              
     END CONSTRUCTOR.
 
@@ -80,6 +86,7 @@ CLASS OEMock.Reflection.ClassFile INHERITS BaseFile:
         IF VALID-OBJECT(Generators)   THEN DELETE OBJECT Generators.
         IF VALID-OBJECT(Interfaces)   THEN DELETE OBJECT Interfaces.
         IF VALID-OBJECT(DataSets)     THEN DELETE OBJECT DataSets.
+        IF VALID-OBJECT(TempTables)   THEN DELETE OBJECT TempTables.
     END DESTRUCTOR.
     
     METHOD PROTECTED LONGCHAR GenerateClass():
@@ -90,15 +97,35 @@ CLASS OEMock.Reflection.ClassFile INHERITS BaseFile:
                               + "&1&6"
                               + "&1&7"
                               + "&1&8"
+                              + "&1&9"
                               + "&1END CLASS.&1",
                                 CHR(10) + CHR(13),
                                 IF INDEX(TypeName, " ") > 0 THEN '"' + TypeName + '"' ELSE TypeName,
                                 (IF InheritsFrom NE ? AND TRIM(InheritsFrom) NE "" THEN "INHERITS " + TRIM(InheritsFrom) + " " ELSE ""),
                                 GenerateInterfaces(),
+                                GenerateTempTables(),
                                 GenerateDataSets(),
                                 GenerateConstructors(),
                                 GenerateMethods(),
                                 Generators:Generate()).
+        RETURN res.
+    END METHOD.
+    
+    METHOD PROTECTED LONGCHAR GenerateTempTables():
+        DEFINE VARIABLE res  AS LONGCHAR NO-UNDO.
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        
+        /* Loop through datasets */
+        ttab = TempTables:MoveFirst().
+        DO WHILE VALID-OBJECT(ttab):
+            ASSIGN res  = res + ttab:Generate()
+                        + CHR(10) + CHR(13)
+                   ttab = TempTables:MoveNext().
+        END.
+        
+        /* Sanity check output */
+        IF res = ? THEN res = "".
+
         RETURN res.
     END METHOD.
     

--- a/OEMock/Reflection/ProcedureFile.cls
+++ b/OEMock/Reflection/ProcedureFile.cls
@@ -9,7 +9,6 @@ USING OEMock.Reflection.MethodList.
 USING OEMock.Generation.GeneratorList.
 USING OEMock.Reflection.DataSetList.
 USING OEMock.Reflection.ParameterList.
-USING OEMock.Reflection.TempTableList.
 
 ROUTINE-LEVEL ON ERROR UNDO, THROW.
 
@@ -33,11 +32,7 @@ CLASS OEMock.Reflection.ProcedureFile INHERITS BaseFile:
 
     DEFINE PUBLIC PROPERTY Procedures AS OEMock.Reflection.MethodList NO-UNDO 
     GET.
-    PROTECTED SET. 
-
-    DEFINE PUBLIC PROPERTY TempTables AS OEMock.Reflection.TempTableList NO-UNDO 
-    GET.
-    PROTECTED SET. 
+    PROTECTED SET.
 
 	CONSTRUCTOR PUBLIC ProcedureFile(INPUT fname AS CHARACTER):
 		SUPER(INPUT fname).
@@ -48,7 +43,6 @@ CLASS OEMock.Reflection.ProcedureFile INHERITS BaseFile:
 		Procedures = NEW MethodList().
 		Generators = NEW GeneratorList().
 		Parameters = NEW ParameterList().
-        TempTables = NEW TempTableList().
 	END CONSTRUCTOR.
 
 	DESTRUCTOR PUBLIC ProcedureFile():
@@ -57,7 +51,6 @@ CLASS OEMock.Reflection.ProcedureFile INHERITS BaseFile:
 	    IF VALID-OBJECT(Procedures) THEN DELETE OBJECT Procedures.
         IF VALID-OBJECT(Generators) THEN DELETE OBJECT Generators.
         IF VALID-OBJECT(Parameters) THEN DELETE OBJECT Parameters.
-        IF VALID-OBJECT(TempTables) THEN DELETE OBJECT TempTables.
 	END DESTRUCTOR.
 	
 	METHOD OVERRIDE PUBLIC LONGCHAR Generate():

--- a/OEMock/Reflection/ProcedureFile.cls
+++ b/OEMock/Reflection/ProcedureFile.cls
@@ -9,6 +9,7 @@ USING OEMock.Reflection.MethodList.
 USING OEMock.Generation.GeneratorList.
 USING OEMock.Reflection.DataSetList.
 USING OEMock.Reflection.ParameterList.
+USING OEMock.Reflection.TempTableList.
 
 ROUTINE-LEVEL ON ERROR UNDO, THROW.
 
@@ -34,6 +35,10 @@ CLASS OEMock.Reflection.ProcedureFile INHERITS BaseFile:
     GET.
     PROTECTED SET. 
 
+    DEFINE PUBLIC PROPERTY TempTables AS OEMock.Reflection.TempTableList NO-UNDO 
+    GET.
+    PROTECTED SET. 
+
 	CONSTRUCTOR PUBLIC ProcedureFile(INPUT fname AS CHARACTER):
 		SUPER(INPUT fname).
 		
@@ -43,6 +48,7 @@ CLASS OEMock.Reflection.ProcedureFile INHERITS BaseFile:
 		Procedures = NEW MethodList().
 		Generators = NEW GeneratorList().
 		Parameters = NEW ParameterList().
+        TempTables = NEW TempTableList().
 	END CONSTRUCTOR.
 
 	DESTRUCTOR PUBLIC ProcedureFile():
@@ -51,14 +57,16 @@ CLASS OEMock.Reflection.ProcedureFile INHERITS BaseFile:
 	    IF VALID-OBJECT(Procedures) THEN DELETE OBJECT Procedures.
         IF VALID-OBJECT(Generators) THEN DELETE OBJECT Generators.
         IF VALID-OBJECT(Parameters) THEN DELETE OBJECT Parameters.
+        IF VALID-OBJECT(TempTables) THEN DELETE OBJECT TempTables.
 	END DESTRUCTOR.
 	
 	METHOD OVERRIDE PUBLIC LONGCHAR Generate():
 	    DEFINE VARIABLE res AS LONGCHAR NO-UNDO.
 	    
-	    ASSIGN res = SUBSTITUTE("&1&2&1&3&1&4&1&5&1&6&1&7&1&8",
+	    ASSIGN res = SUBSTITUTE("&1&2&1&3&1&4&1&5&1&6&1&7&1&8&1&9",
 	                            CHR(10) + CHR(13),
 	                            GenerateUsing(),
+                                GenerateTempTables(),
 	                            GenerateDataSets(),
 	                            GenerateParameters(),
 	                            GenerateFunctionForwards(),
@@ -68,6 +76,24 @@ CLASS OEMock.Reflection.ProcedureFile INHERITS BaseFile:
 
         RETURN res.
 	END METHOD.
+    
+    METHOD PROTECTED LONGCHAR GenerateTempTables():
+        DEFINE VARIABLE res  AS LONGCHAR NO-UNDO.
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        
+        /* Loop through datasets */
+        ttab = TempTables:MoveFirst().
+        DO WHILE VALID-OBJECT(ttab):
+            ASSIGN res  = res + ttab:Generate()
+                        + CHR(10) + CHR(13)
+                   ttab = TempTables:MoveNext().
+        END.
+        
+        /* Sanity check output */
+        IF res = ? THEN res = "".
+
+        RETURN res.
+    END METHOD.
     
     METHOD PROTECTED LONGCHAR GenerateDataSets():
         DEFINE VARIABLE res  AS LONGCHAR NO-UNDO.

--- a/OEMock/Reflection/TempTable.cls
+++ b/OEMock/Reflection/TempTable.cls
@@ -4,10 +4,16 @@
   ----------------------------------------------------------------------*/
 
 USING Progress.Lang.*.
+USING OEMock.Reflection.TempTableField.
+USING OEMock.Reflection.TempTableFieldList.
 
 ROUTINE-LEVEL ON ERROR UNDO, THROW.
 
 CLASS OEMock.Reflection.TempTable:
+    
+    DEFINE PUBLIC PROPERTY Fields AS OEMock.Reflection.TempTableFieldList NO-UNDO
+    GET.
+    PROTECTED SET.
         
     DEFINE PUBLIC PROPERTY Name AS CHARACTER NO-UNDO 
     GET.
@@ -32,7 +38,8 @@ CLASS OEMock.Reflection.TempTable:
     CONSTRUCTOR PUBLIC TempTable(INPUT nam AS CHARACTER):
         SUPER().
         
-        ASSIGN Name               = nam
+        ASSIGN THIS-OBJECT:Fields = NEW TempTableFieldList()
+               Name               = nam
                NamespacePrefix    = ""
                NamespaceURI       = ""
                NoUndo             = TRUE
@@ -40,11 +47,13 @@ CLASS OEMock.Reflection.TempTable:
     END CONSTRUCTOR.
 
     DESTRUCTOR PUBLIC TempTable():
+        IF VALID-OBJECT(THIS-OBJECT:Fields) THEN DELETE OBJECT THIS-OBJECT:Fields.
     END DESTRUCTOR.
     
     METHOD PUBLIC LONGCHAR Generate():
         
-        DEFINE VARIABLE res AS LONGCHAR        NO-UNDO.
+        DEFINE VARIABLE res AS LONGCHAR       NO-UNDO.
+        DEFINE VARIABLE fld AS TempTableField NO-UNDO.
         
         res = SUBSTITUTE("DEFINE &2TEMP-TABLE &3&4&5&6&1",
                          CHR(10),
@@ -53,9 +62,18 @@ CLASS OEMock.Reflection.TempTable:
                          (IF NoUndo THEN " NO-UNDO " ELSE ""),
                          (IF NamespacePrefix NE ? AND NamespacePrefix NE "" THEN "NAMESPACE-PREFIX ~"" + NamespacePrefix + "~" " ELSE ""),
                          (IF NamespaceURI    NE ? AND NamespaceURI    NE "" THEN "NAMESPACE-URI ~""    + NamespaceURI    + "~" " ELSE "")).
+
+        /* Build field list */
+        fld = THIS-OBJECT:Fields:MoveFirst().
+        DO WHILE(VALID-OBJECT(fld)):
+            res = res + " " + fld:Generate().
+            fld = THIS-OBJECT:Fields:MoveNext().
+        END.
+
+        /* Trim contents and add ending fullstop */
+        ASSIGN res = TRIM(TRIM(res),".") + ".".
+                                 
         RETURN res.
     END METHOD.
     
-    
-
 END CLASS.

--- a/OEMock/Reflection/TempTable.cls
+++ b/OEMock/Reflection/TempTable.cls
@@ -6,12 +6,18 @@
 USING Progress.Lang.*.
 USING OEMock.Reflection.TempTableField.
 USING OEMock.Reflection.TempTableFieldList.
+USING OEMock.Reflection.TempTableIndex.
+USING OEMock.Reflection.TempTableIndexList.
 
 ROUTINE-LEVEL ON ERROR UNDO, THROW.
 
 CLASS OEMock.Reflection.TempTable:
     
     DEFINE PUBLIC PROPERTY Fields AS OEMock.Reflection.TempTableFieldList NO-UNDO
+    GET.
+    PROTECTED SET.
+    
+    DEFINE PUBLIC PROPERTY Indexes AS OEMock.Reflection.TempTableIndexList NO-UNDO
     GET.
     PROTECTED SET.
         
@@ -38,22 +44,25 @@ CLASS OEMock.Reflection.TempTable:
     CONSTRUCTOR PUBLIC TempTable(INPUT nam AS CHARACTER):
         SUPER().
         
-        ASSIGN THIS-OBJECT:Fields = NEW TempTableFieldList()
-               Name               = nam
-               NamespacePrefix    = ""
-               NamespaceURI       = ""
-               NoUndo             = TRUE
-               THIS-OBJECT:Static = FALSE.
+        ASSIGN THIS-OBJECT:Fields  = NEW TempTableFieldList()
+               THIS-OBJECT:Indexes = NEW TempTableIndexList()
+               Name                = nam
+               NamespacePrefix     = ""
+               NamespaceURI        = ""
+               NoUndo              = TRUE
+               THIS-OBJECT:Static  = FALSE.
     END CONSTRUCTOR.
 
     DESTRUCTOR PUBLIC TempTable():
-        IF VALID-OBJECT(THIS-OBJECT:Fields) THEN DELETE OBJECT THIS-OBJECT:Fields.
+        IF VALID-OBJECT(THIS-OBJECT:Fields)  THEN DELETE OBJECT THIS-OBJECT:Fields.
+        IF VALID-OBJECT(THIS-OBJECT:Indexes) THEN DELETE OBJECT THIS-OBJECT:Indexes.
     END DESTRUCTOR.
     
     METHOD PUBLIC LONGCHAR Generate():
         
         DEFINE VARIABLE res AS LONGCHAR       NO-UNDO.
         DEFINE VARIABLE fld AS TempTableField NO-UNDO.
+        DEFINE VARIABLE idx AS TempTableIndex NO-UNDO.
         
         res = SUBSTITUTE("DEFINE &2TEMP-TABLE &3&4&5&6&1",
                          CHR(10),
@@ -68,6 +77,13 @@ CLASS OEMock.Reflection.TempTable:
         DO WHILE(VALID-OBJECT(fld)):
             res = res + " " + fld:Generate().
             fld = THIS-OBJECT:Fields:MoveNext().
+        END.
+        
+        /* Build index list */
+        idx = THIS-OBJECT:Indexes:MoveFirst().
+        DO WHILE(VALID-OBJECT(idx)):
+            res = res + " " + idx:Generate().
+            idx = THIS-OBJECT:Indexes:MoveNext().
         END.
 
         /* Trim contents and add ending fullstop */

--- a/OEMock/Reflection/TempTable.cls
+++ b/OEMock/Reflection/TempTable.cls
@@ -1,0 +1,61 @@
+ /*------------------------------------------------------------------------
+    File        : TempTable
+    Purpose     : Represents a Temp-Table in code.
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Reflection.TempTable:
+        
+    DEFINE PUBLIC PROPERTY Name AS CHARACTER NO-UNDO 
+    GET.
+    PROTECTED SET.
+        
+    DEFINE PUBLIC PROPERTY NamespacePrefix AS CHARACTER NO-UNDO 
+    GET.
+    SET.
+        
+    DEFINE PUBLIC PROPERTY NamespaceURI AS CHARACTER NO-UNDO 
+    GET.
+    SET.
+
+	DEFINE PUBLIC PROPERTY NoUndo AS LOGICAL INITIAL TRUE NO-UNDO 
+	GET.
+	SET.
+
+    DEFINE PUBLIC PROPERTY Static AS LOGICAL INITIAL FALSE NO-UNDO 
+    GET.
+    SET.
+    
+    CONSTRUCTOR PUBLIC TempTable(INPUT nam AS CHARACTER):
+        SUPER().
+        
+        ASSIGN Name               = nam
+               NamespacePrefix    = ""
+               NamespaceURI       = ""
+               NoUndo             = TRUE
+               THIS-OBJECT:Static = FALSE.
+    END CONSTRUCTOR.
+
+    DESTRUCTOR PUBLIC TempTable():
+    END DESTRUCTOR.
+    
+    METHOD PUBLIC LONGCHAR Generate():
+        
+        DEFINE VARIABLE res AS LONGCHAR        NO-UNDO.
+        
+        res = SUBSTITUTE("DEFINE &2TEMP-TABLE &3&4&5&6&1",
+                         CHR(10),
+                         (IF THIS-OBJECT:Static THEN "STATIC " ELSE ""),
+                         NAME,
+                         (IF NoUndo THEN " NO-UNDO " ELSE ""),
+                         (IF NamespacePrefix NE ? AND NamespacePrefix NE "" THEN "NAMESPACE-PREFIX ~"" + NamespacePrefix + "~" " ELSE ""),
+                         (IF NamespaceURI    NE ? AND NamespaceURI    NE "" THEN "NAMESPACE-URI ~""    + NamespaceURI    + "~" " ELSE "")).
+        RETURN res.
+    END METHOD.
+    
+    
+
+END CLASS.

--- a/OEMock/Reflection/TempTableField.cls
+++ b/OEMock/Reflection/TempTableField.cls
@@ -70,7 +70,8 @@ CLASS OEMock.Reflection.TempTableField:
 	END DESTRUCTOR.
 	
 	METHOD PUBLIC LONGCHAR Generate():
-	    DEFINE VARIABLE res AS LONGCHAR NO-UNDO.
+	    DEFINE VARIABLE res  AS LONGCHAR NO-UNDO.
+	    DEFINE VARIABLE init AS CHARACTER NO-UNDO.
 	    
 	    ASSIGN res = SUBSTITUTE("FIELD &1 AS &2",
 	                            Name,
@@ -78,9 +79,17 @@ CLASS OEMock.Reflection.TempTableField:
 	    
 	    IF Initial NE "" THEN
 	    DO:
+	        ASSIGN Init = Initial.
+	        
+	        /* Check for values that need to be formatted */
+	        IF (DataType = "CHARACTER" OR DataType = "LONGCHAR") AND Init NE ? THEN
+	        DO:
+	            ASSIGN Init = SUBSTITUTE('"&1"', Init).
+	        END.
+	        
 	        ASSIGN res = SUBSTITUTE("&1 INITIAL &2",
 	                                res,
-	                                Initial).
+	                                Init).
 	    END.
 	    
 	    IF Extent GT 0 AND Extent NE ? THEN

--- a/OEMock/Reflection/TempTableField.cls
+++ b/OEMock/Reflection/TempTableField.cls
@@ -1,0 +1,135 @@
+ /*------------------------------------------------------------------------
+    File        : TempTableField
+    Purpose     : Represents a field on a temp-table
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Reflection.TempTableField:
+    
+	DEFINE PUBLIC PROPERTY DataType AS CHARACTER NO-UNDO 
+	GET.
+	SET. 
+
+	DEFINE PUBLIC PROPERTY Extent AS INTEGER INITIAL 0 NO-UNDO 
+	GET.
+	SET(INPUT arg AS INTEGER):
+       IF arg < 0 OR arg = ? THEN
+            ASSIGN arg = 0.
+
+       THIS-OBJECT:Extent = arg.
+	END SET.
+	 
+
+	DEFINE PUBLIC PROPERTY Initial AS CHARACTER INITIAL "" NO-UNDO 
+	GET.
+	SET. 
+
+	DEFINE PUBLIC PROPERTY Name AS CHARACTER NO-UNDO 
+	GET.
+	SET. 
+
+	DEFINE PUBLIC PROPERTY SerializeHidden AS LOGICAL INITIAL FALSE NO-UNDO 
+	GET.
+	SET. 
+
+	DEFINE PUBLIC PROPERTY SerializeName AS CHARACTER NO-UNDO 
+	GET.
+	SET. 
+	
+    DEFINE PUBLIC PROPERTY XMLDataType AS CHARACTER NO-UNDO 
+    GET.
+    SET. 
+    
+    DEFINE PUBLIC PROPERTY XMLNodeType AS CHARACTER NO-UNDO 
+    GET.
+    SET. 
+    
+    DEFINE PUBLIC PROPERTY XMLNodeName AS CHARACTER NO-UNDO 
+    GET.
+    SET. 
+
+	CONSTRUCTOR PUBLIC TempTableField(INPUT nam AS CHARACTER, INPUT dType AS CHARACTER):
+		SUPER ().
+		
+		ASSIGN DataType        = dType
+		       Name            = nam
+		       Extent          = 0
+		       Initial         = ""
+		       SerializeHidden = FALSE
+		       SerializeName   = ""
+		       XMLDataType     = "" 
+               XMLNodeType     = ""
+               XMLNodeName     = "".
+	END CONSTRUCTOR.
+
+	DESTRUCTOR PUBLIC TempTableField():
+
+	END DESTRUCTOR.
+	
+	METHOD PUBLIC LONGCHAR Generate():
+	    DEFINE VARIABLE res AS LONGCHAR NO-UNDO.
+	    
+	    ASSIGN res = SUBSTITUTE("FIELD &1 AS &2",
+	                            Name,
+	                            DataType).
+	    
+	    IF Initial NE "" THEN
+	    DO:
+	        ASSIGN res = SUBSTITUTE("&1 INITIAL &2",
+	                                res,
+	                                Initial).
+	    END.
+	    
+	    IF Extent GT 0 AND Extent NE ? THEN
+	    DO:
+	        ASSIGN res = SUBSTITUTE("&1 EXTENT &2",
+                                    res,
+                                    TRIM(STRING(THIS-OBJECT:Extent, ">>>>>>>>>>>>>>>>>>>9"))).
+	    END.
+	    
+	    IF SerializeHidden EQ TRUE THEN
+	    DO:
+	        ASSIGN res = SUBSTITUTE("&1 SERIALIZE-HIDDEN",
+                                    res).
+	    END.
+        
+        IF TRIM(SerializeName) NE "" AND SerializeName NE ? THEN
+        DO:
+            ASSIGN res = SUBSTITUTE("&1 SERIALIZE-NAME ~"&2~"",
+                                    res,
+                                    SerializeName).
+        END.
+        
+        IF TRIM(XMLDataType) NE "" AND XMLDataType NE ? THEN
+        DO:
+            ASSIGN res = SUBSTITUTE("&1 XML-DATA-TYPE ~"&2~"",
+                                    res,
+                                    XMLDataType).
+        END.
+        
+
+        IF TRIM(XMLNodeType) NE "" AND XMLNodeType NE ? THEN
+        DO:
+            ASSIGN res = SUBSTITUTE("&1 XML-NODE-TYPE ~"&2~"",
+                                    res,
+                                    XMLNodeType).
+        END.
+        
+        
+        IF TRIM(XMLNodeName) NE "" AND XMLNodeName NE ? THEN
+        DO:
+            ASSIGN res = SUBSTITUTE("&1 XML-NODE-NAME ~"&2~"",
+                                    res,
+                                    XMLNodeName).
+        END.
+	    
+	    /* Ensure appropriate spacing between this statement and the next */
+	    ASSIGN res = res + CHR(10).
+	    
+	    RETURN res.
+	END METHOD.
+
+END CLASS.

--- a/OEMock/Reflection/TempTableFieldList.cls
+++ b/OEMock/Reflection/TempTableFieldList.cls
@@ -1,0 +1,51 @@
+ /*------------------------------------------------------------------------
+    File        : TempTableFieldList
+    Purpose     : Holds list of TempTableField objects
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEMock.Reflection.TempTableField.
+USING OEMock.Util.BaseList.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Reflection.TempTableFieldList INHERITS BaseList: 
+
+	CONSTRUCTOR PUBLIC TempTableFieldList():
+		SUPER().
+	END CONSTRUCTOR.
+    
+    METHOD PUBLIC LOGICAL AddTempTableField(INPUT fil AS TempTableField):
+        RETURN SUPER:AddItem(fil).
+    END METHOD.
+    
+    METHOD OVERRIDE PUBLIC VOID EmptyList():
+        SUPER:EmptyList().
+    END METHOD.
+    
+    METHOD PROTECTED TempTableField CastToTempTableField(INPUT obj AS Progress.Lang.Object):
+        DEFINE VARIABLE res AS TempTableField NO-UNDO.
+        IF VALID-OBJECT(obj) AND obj:GetClass():IsA("OEMock.Reflection.TempTableField")THEN
+        DO:
+            res = DYNAMIC-CAST(obj, obj:GetClass():TypeName).
+        END.
+        RETURN res.
+    END METHOD.
+    
+    METHOD PUBLIC TempTableField MoveFirst():
+        RETURN CastToTempTableField(GetFirst()).
+    END METHOD.
+    
+    METHOD PUBLIC TempTableField MoveLast():
+        RETURN CastToTempTableField(GetLast()).
+    END METHOD.
+    
+    METHOD PUBLIC TempTableField MoveNext():
+        RETURN CastToTempTableField(GetNext()).
+    END METHOD.
+    
+    METHOD PUBLIC TempTableField MovePrev():
+        RETURN CastToTempTableField(GetPrev()).
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Reflection/TempTableIndex.cls
+++ b/OEMock/Reflection/TempTableIndex.cls
@@ -1,0 +1,58 @@
+ /*------------------------------------------------------------------------
+    File        : TempTableIndex
+    Purpose     : Represents a temp-table index 
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Reflection.TempTableIndex:
+    
+    
+		
+	DEFINE PUBLIC PROPERTY Name AS CHARACTER NO-UNDO 
+	GET.
+	SET. 
+
+	DEFINE PUBLIC PROPERTY Primary AS LOGICAL INITIAL FALSE NO-UNDO 
+	GET.
+	SET. 
+
+	DEFINE PUBLIC PROPERTY Unique AS LOGICAL INITIAL FALSE NO-UNDO 
+	GET.
+	SET. 
+
+	DEFINE PUBLIC PROPERTY WordIndex AS LOGICAL INITIAL FALSE NO-UNDO 
+	GET.
+	SET. 
+
+	CONSTRUCTOR PUBLIC TempTableIndex(INPUT nam AS CHARACTER):
+		SUPER ().
+		
+		ASSIGN Name                = nam
+		       THIS-OBJECT:Primary = FALSE
+		       THIS-OBJECT:Unique  = FALSE
+		       WordIndex           = FALSE.
+	END CONSTRUCTOR.
+
+	DESTRUCTOR PUBLIC TempTableIndex():
+
+	END DESTRUCTOR.
+	
+	METHOD PUBLIC LONGCHAR Generate():
+	    
+	    DEFINE VARIABLE res AS LONGCHAR NO-UNDO.
+	    
+	    ASSIGN res = SUBSTITUTE("INDEX &1 &2&3&4&5",
+	                            Name,
+	                            (IF THIS-OBJECT:Primary OR THIS-OBJECT:Unique OR WordIndex THEN "IS " ELSE ""),
+	                            (IF THIS-OBJECT:Primary THEN "PRIMARY " ELSE ""),
+	                            (IF THIS-OBJECT:Unique  THEN "UNIQUE " ELSE ""),
+                                (IF WordIndex           THEN "WORD-INDEX " ELSE "")).
+	    
+	    RETURN res.
+
+	END METHOD.
+
+END CLASS.

--- a/OEMock/Reflection/TempTableIndex.cls
+++ b/OEMock/Reflection/TempTableIndex.cls
@@ -50,8 +50,7 @@ CLASS OEMock.Reflection.TempTableIndex:
 	    DEFINE VARIABLE res AS LONGCHAR NO-UNDO.
 	    DEFINE VARIABLE fld AS TempTableIndexField NO-UNDO.
 	    
-	    ASSIGN res = SUBSTITUTE("INDEX &2 &3&4&5&6&1",
-	                            CHR(13),
+	    ASSIGN res = SUBSTITUTE("INDEX &1 &2&3&4&5",
 	                            Name,
 	                            (IF THIS-OBJECT:Primary OR THIS-OBJECT:Unique OR WordIndex THEN "IS " ELSE ""),
 	                            (IF THIS-OBJECT:Primary THEN "PRIMARY " ELSE ""),
@@ -64,6 +63,8 @@ CLASS OEMock.Reflection.TempTableIndex:
             res = res + " " + fld:Generate().
             fld = THIS-OBJECT:Fields:MoveNext().
         END.
+        
+        ASSIGN res = TRIM(res) + CHR(13).
 	    
 	    RETURN res.
 

--- a/OEMock/Reflection/TempTableIndex.cls
+++ b/OEMock/Reflection/TempTableIndex.cls
@@ -4,12 +4,16 @@
   ----------------------------------------------------------------------*/
 
 USING Progress.Lang.*.
+USING OEMock.Reflection.TempTableIndexField.
+USING OEMock.Reflection.TempTableIndexFieldList.
 
 ROUTINE-LEVEL ON ERROR UNDO, THROW.
 
 CLASS OEMock.Reflection.TempTableIndex:
     
-    
+    DEFINE PUBLIC PROPERTY Fields AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO
+    GET.
+    PROTECTED SET.
 		
 	DEFINE PUBLIC PROPERTY Name AS CHARACTER NO-UNDO 
 	GET.
@@ -30,26 +34,36 @@ CLASS OEMock.Reflection.TempTableIndex:
 	CONSTRUCTOR PUBLIC TempTableIndex(INPUT nam AS CHARACTER):
 		SUPER ().
 		
-		ASSIGN Name                = nam
+		ASSIGN THIS-OBJECT:Fields  = NEW TempTableIndexFieldList()
+		       Name                = nam
 		       THIS-OBJECT:Primary = FALSE
 		       THIS-OBJECT:Unique  = FALSE
 		       WordIndex           = FALSE.
 	END CONSTRUCTOR.
 
 	DESTRUCTOR PUBLIC TempTableIndex():
-
+        IF VALID-OBJECT(THIS-OBJECT:Fields) THEN DELETE OBJECT THIS-OBJECT:Fields.
 	END DESTRUCTOR.
 	
 	METHOD PUBLIC LONGCHAR Generate():
 	    
 	    DEFINE VARIABLE res AS LONGCHAR NO-UNDO.
+	    DEFINE VARIABLE fld AS TempTableIndexField NO-UNDO.
 	    
-	    ASSIGN res = SUBSTITUTE("INDEX &1 &2&3&4&5",
+	    ASSIGN res = SUBSTITUTE("INDEX &2 &3&4&5&6&1",
+	                            CHR(13),
 	                            Name,
 	                            (IF THIS-OBJECT:Primary OR THIS-OBJECT:Unique OR WordIndex THEN "IS " ELSE ""),
 	                            (IF THIS-OBJECT:Primary THEN "PRIMARY " ELSE ""),
 	                            (IF THIS-OBJECT:Unique  THEN "UNIQUE " ELSE ""),
                                 (IF WordIndex           THEN "WORD-INDEX " ELSE "")).
+        
+        /* Build field list */
+        fld = THIS-OBJECT:Fields:MoveFirst().
+        DO WHILE(VALID-OBJECT(fld)):
+            res = res + " " + fld:Generate().
+            fld = THIS-OBJECT:Fields:MoveNext().
+        END.
 	    
 	    RETURN res.
 

--- a/OEMock/Reflection/TempTableIndexField.cls
+++ b/OEMock/Reflection/TempTableIndexField.cls
@@ -1,0 +1,38 @@
+ /*------------------------------------------------------------------------
+    File        : TempTableIndexField
+    Purpose     : Class representing a field in a temp-table index.
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Reflection.TempTableIndexField:
+		
+	DEFINE PUBLIC PROPERTY Descending AS LOGICAL NO-UNDO INITIAL FALSE
+	GET.
+	SET. 
+
+	DEFINE PUBLIC PROPERTY Name AS CHARACTER NO-UNDO 
+	GET.
+	SET. 
+
+	CONSTRUCTOR PUBLIC TempTableIndexField(INPUT nam AS CHARACTER):
+		SUPER().
+		
+		ASSIGN Name                   = nam
+		       THIS-OBJECT:Descending = FALSE.
+	END CONSTRUCTOR.
+	
+	METHOD PUBLIC LONGCHAR Generate():
+	    
+	    DEFINE VARIABLE res AS LONGCHAR NO-UNDO.
+	    
+	    ASSIGN res = SUBSTITUTE("&1 &2",
+	                            Name,
+	                            (IF THIS-OBJECT:DESCENDING THEN "DESCENDING " ELSE "ASCENDING ")).
+	    
+	    RETURN res.
+	END METHOD.
+
+END CLASS.

--- a/OEMock/Reflection/TempTableIndexFieldList.cls
+++ b/OEMock/Reflection/TempTableIndexFieldList.cls
@@ -1,0 +1,51 @@
+ /*------------------------------------------------------------------------
+    File        : TempTableIndexFieldList
+    Purpose     : Holds list of TempTableIndexField objects
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEMock.Reflection.TempTableIndexField.
+USING OEMock.Util.BaseList.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Reflection.TempTableIndexFieldList INHERITS BaseList: 
+
+	CONSTRUCTOR PUBLIC TempTableIndexFieldList():
+		SUPER().
+	END CONSTRUCTOR.
+    
+    METHOD PUBLIC LOGICAL AddTempTableIndexField(INPUT fil AS TempTableIndexField):
+        RETURN SUPER:AddItem(fil).
+    END METHOD.
+    
+    METHOD OVERRIDE PUBLIC VOID EmptyList():
+        SUPER:EmptyList().
+    END METHOD.
+    
+    METHOD PROTECTED TempTableIndexField CastToTempTableIndexField(INPUT obj AS Progress.Lang.Object):
+        DEFINE VARIABLE res AS TempTableIndexField NO-UNDO.
+        IF VALID-OBJECT(obj) AND obj:GetClass():IsA("OEMock.Reflection.TempTableIndexField")THEN
+        DO:
+            res = DYNAMIC-CAST(obj, obj:GetClass():TypeName).
+        END.
+        RETURN res.
+    END METHOD.
+    
+    METHOD PUBLIC TempTableIndexField MoveFirst():
+        RETURN CastToTempTableIndexField(GetFirst()).
+    END METHOD.
+    
+    METHOD PUBLIC TempTableIndexField MoveLast():
+        RETURN CastToTempTableIndexField(GetLast()).
+    END METHOD.
+    
+    METHOD PUBLIC TempTableIndexField MoveNext():
+        RETURN CastToTempTableIndexField(GetNext()).
+    END METHOD.
+    
+    METHOD PUBLIC TempTableIndexField MovePrev():
+        RETURN CastToTempTableIndexField(GetPrev()).
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Reflection/TempTableIndexList.cls
+++ b/OEMock/Reflection/TempTableIndexList.cls
@@ -1,0 +1,51 @@
+ /*------------------------------------------------------------------------
+    File        : TempTableIndexList
+    Purpose     : Holds list of TempTableIndex objects
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEMock.Reflection.TempTableIndex.
+USING OEMock.Util.BaseList.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Reflection.TempTableIndexList INHERITS BaseList: 
+
+	CONSTRUCTOR PUBLIC TempTableIndexList():
+		SUPER().
+	END CONSTRUCTOR.
+    
+    METHOD PUBLIC LOGICAL AddTempTableIndex(INPUT fil AS TempTableIndex):
+        RETURN SUPER:AddItem(fil).
+    END METHOD.
+    
+    METHOD OVERRIDE PUBLIC VOID EmptyList():
+        SUPER:EmptyList().
+    END METHOD.
+    
+    METHOD PROTECTED TempTableIndex CastToTempTableIndex(INPUT obj AS Progress.Lang.Object):
+        DEFINE VARIABLE res AS TempTableIndex NO-UNDO.
+        IF VALID-OBJECT(obj) AND obj:GetClass():IsA("OEMock.Reflection.TempTableIndex")THEN
+        DO:
+            res = DYNAMIC-CAST(obj, obj:GetClass():TypeName).
+        END.
+        RETURN res.
+    END METHOD.
+    
+    METHOD PUBLIC TempTableIndex MoveFirst():
+        RETURN CastToTempTableIndex(GetFirst()).
+    END METHOD.
+    
+    METHOD PUBLIC TempTableIndex MoveLast():
+        RETURN CastToTempTableIndex(GetLast()).
+    END METHOD.
+    
+    METHOD PUBLIC TempTableIndex MoveNext():
+        RETURN CastToTempTableIndex(GetNext()).
+    END METHOD.
+    
+    METHOD PUBLIC TempTableIndex MovePrev():
+        RETURN CastToTempTableIndex(GetPrev()).
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Reflection/TempTableList.cls
+++ b/OEMock/Reflection/TempTableList.cls
@@ -1,0 +1,51 @@
+ /*------------------------------------------------------------------------
+    File        : TempTableList
+    Purpose     : Holds list of TempTable objects
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEMock.Reflection.TempTable.
+USING OEMock.Util.BaseList.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Reflection.TempTableList INHERITS BaseList: 
+
+	CONSTRUCTOR PUBLIC TempTableList():
+		SUPER().
+	END CONSTRUCTOR.
+    
+    METHOD PUBLIC LOGICAL AddTempTable(INPUT fil AS TempTable):
+        RETURN SUPER:AddItem(fil).
+    END METHOD.
+    
+    METHOD OVERRIDE PUBLIC VOID EmptyList():
+        SUPER:EmptyList().
+    END METHOD.
+    
+    METHOD PROTECTED TempTable CastToTempTable(INPUT obj AS Progress.Lang.Object):
+        DEFINE VARIABLE res AS TempTable NO-UNDO.
+        IF VALID-OBJECT(obj) AND obj:GetClass():IsA("OEMock.Reflection.TempTable")THEN
+        DO:
+            res = DYNAMIC-CAST(obj, obj:GetClass():TypeName).
+        END.
+        RETURN res.
+    END METHOD.
+    
+    METHOD PUBLIC TempTable MoveFirst():
+        RETURN CastToTempTable(GetFirst()).
+    END METHOD.
+    
+    METHOD PUBLIC TempTable MoveLast():
+        RETURN CastToTempTable(GetLast()).
+    END METHOD.
+    
+    METHOD PUBLIC TempTable MoveNext():
+        RETURN CastToTempTable(GetNext()).
+    END METHOD.
+    
+    METHOD PUBLIC TempTable MovePrev():
+        RETURN CastToTempTable(GetPrev()).
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/BaseDoubleTester.cls
+++ b/OEMock/Tests/BaseDoubleTester.cls
@@ -15,6 +15,10 @@ CLASS OEMock.Tests.BaseDoubleTester:
     
     DEFINE PROTECTED VARIABLE TestDir AS CHARACTER NO-UNDO INITIAL "tests/".
     
+    /* Basic temp-table used to pass to 'AddTempTable' */
+    DEFINE PROTECTED TEMP-TABLE ttTestTable NO-UNDO
+        FIELD CharField AS CHARACTER.
+    
     @Test.
     METHOD PUBLIC VOID ConstructorSetsFile():
         DEFINE VARIABLE dbl AS BaseDouble NO-UNDO.
@@ -165,6 +169,22 @@ CLASS OEMock.Tests.BaseDoubleTester:
         procFile = DYNAMIC-CAST(dbl:File, dbl:File:GetClass():TypeName).
         
         Assert:AreEqual(procFile:Parameters:Count, 1).
+        
+        IF VALID-OBJECT(insp) THEN DELETE OBJECT(insp).
+        IF VALID-OBJECT(dbl)  THEN DELETE OBJECT(dbl). 
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID AddTempTableAddsToFileTempTables():
+        DEFINE VARIABLE dbl AS BaseDouble NO-UNDO.
+        DEFINE VARIABLE insp AS ProcedureInspector NO-UNDO.
+        
+        insp = NEW ProcedureInspector('OEMock/Tests/Inspection/TestProcedure.p').
+        dbl = NEW BaseDouble(insp:Inspect(), TestDir).
+        
+        dbl:AddTempTable(INPUT TEMP-TABLE ttTestTable:HANDLE).
+        
+        Assert:AreEqual(dbl:File:TempTables:Count, 1).
         
         IF VALID-OBJECT(insp) THEN DELETE OBJECT(insp).
         IF VALID-OBJECT(dbl)  THEN DELETE OBJECT(dbl). 

--- a/OEMock/Tests/Reflection/AllTests.cls
+++ b/OEMock/Tests/Reflection/AllTests.cls
@@ -30,6 +30,7 @@ CLASS OEMock.Tests.Reflection.AllTests INHERITS TestSuite:
     AddTest(NEW TempTableTester()).
     AddTest(NEW TempTableListTester()).
     AddTest(NEW TempTableFieldTester()).
+    AddTest(NEW TempTableFieldListTester()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/AllTests.cls
+++ b/OEMock/Tests/Reflection/AllTests.cls
@@ -34,6 +34,7 @@ CLASS OEMock.Tests.Reflection.AllTests INHERITS TestSuite:
     AddTest(NEW TempTableIndexTester()).
     AddTest(NEW TempTableIndexListTester()).
     AddTest(NEW TempTableIndexFieldTester()).
+    AddTest(NEW TempTableIndexFieldListTester()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/AllTests.cls
+++ b/OEMock/Tests/Reflection/AllTests.cls
@@ -28,6 +28,7 @@ CLASS OEMock.Tests.Reflection.AllTests INHERITS TestSuite:
     AddTest(NEW DataSetListTester()).
     AddTest(NEW DataSetParameterTester()).
     AddTest(NEW TempTableTester()).
+    AddTest(NEW TempTableListTester()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/AllTests.cls
+++ b/OEMock/Tests/Reflection/AllTests.cls
@@ -31,6 +31,7 @@ CLASS OEMock.Tests.Reflection.AllTests INHERITS TestSuite:
     AddTest(NEW TempTableListTester()).
     AddTest(NEW TempTableFieldTester()).
     AddTest(NEW TempTableFieldListTester()).
+    AddTest(NEW TempTableIndexTester()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/AllTests.cls
+++ b/OEMock/Tests/Reflection/AllTests.cls
@@ -27,6 +27,7 @@ CLASS OEMock.Tests.Reflection.AllTests INHERITS TestSuite:
     AddTest(NEW DataSetTester()).
     AddTest(NEW DataSetListTester()).
     AddTest(NEW DataSetParameterTester()).
+    AddTest(NEW TempTableTester()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/AllTests.cls
+++ b/OEMock/Tests/Reflection/AllTests.cls
@@ -33,6 +33,7 @@ CLASS OEMock.Tests.Reflection.AllTests INHERITS TestSuite:
     AddTest(NEW TempTableFieldListTester()).
     AddTest(NEW TempTableIndexTester()).
     AddTest(NEW TempTableIndexListTester()).
+    AddTest(NEW TempTableIndexFieldTester()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/AllTests.cls
+++ b/OEMock/Tests/Reflection/AllTests.cls
@@ -29,6 +29,7 @@ CLASS OEMock.Tests.Reflection.AllTests INHERITS TestSuite:
     AddTest(NEW DataSetParameterTester()).
     AddTest(NEW TempTableTester()).
     AddTest(NEW TempTableListTester()).
+    AddTest(NEW TempTableFieldTester()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/AllTests.cls
+++ b/OEMock/Tests/Reflection/AllTests.cls
@@ -32,6 +32,7 @@ CLASS OEMock.Tests.Reflection.AllTests INHERITS TestSuite:
     AddTest(NEW TempTableFieldTester()).
     AddTest(NEW TempTableFieldListTester()).
     AddTest(NEW TempTableIndexTester()).
+    AddTest(NEW TempTableIndexListTester()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/OEMock/Tests/Reflection/BaseFileTester.cls
+++ b/OEMock/Tests/Reflection/BaseFileTester.cls
@@ -21,13 +21,22 @@ CLASS OEMock.Tests.Reflection.BaseFileTester:
     
     @Test.
     METHOD PUBLIC VOID ConstructorCreatesUsingList():
-        DEFINE VARIABLE clsfile AS ClassFile NO-UNDO.
+        DEFINE VARIABLE fil AS BaseFile NO-UNDO.
+        fil = NEW BaseFile('filename').
         
-        clsfile = NEW ClassFile("FileName", "OEMock.Tests.Util.ListObject").
+        Assert:IsTrue(VALID-OBJECT(fil:UsingList)).
         
-        Assert:IsTrue(VALID-OBJECT(clsfile:UsingList)).
+        IF VALID-OBJECT(fil) THEN DELETE OBJECT fil.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorCreatesTempTableList():
+        DEFINE VARIABLE fil AS BaseFile NO-UNDO.
+        fil = NEW BaseFile('filename').
         
-        IF VALID-OBJECT(clsfile) THEN DELETE OBJECT clsfile.
+        Assert:IsTrue(VALID-OBJECT(fil:TempTables)).
+        
+        IF VALID-OBJECT(fil) THEN DELETE OBJECT fil.
     END METHOD.
     
     @Test.

--- a/OEMock/Tests/Reflection/ClassFileTester.cls
+++ b/OEMock/Tests/Reflection/ClassFileTester.cls
@@ -67,6 +67,17 @@ CLASS OEMock.Tests.Reflection.ClassFileTester:
     END METHOD.
     
     @Test.
+    METHOD PUBLIC VOID ConstructorCreatesTempTablesList():
+        DEFINE VARIABLE clsfile AS ClassFile NO-UNDO.
+        
+        clsfile = NEW ClassFile("FileName", "OEMock.Tests.Util.ListObject").
+        
+        Assert:IsTrue(VALID-OBJECT(clsfile:TempTables)).
+        
+        IF VALID-OBJECT(clsfile) THEN DELETE OBJECT clsfile.
+    END METHOD.
+    
+    @Test.
     METHOD PUBLIC VOID ConstructorCreatesDataSetsList():
         DEFINE VARIABLE clsfile AS ClassFile NO-UNDO.
         
@@ -205,6 +216,20 @@ CLASS OEMock.Tests.Reflection.ClassFileTester:
         AssertString:Contains(clsCode, 
                               "END CLASS.").
                               
+        IF VALID-OBJECT(clsfile) THEN DELETE OBJECT clsfile.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesTempTables():
+        DEFINE VARIABLE clsfile AS ClassFile NO-UNDO.
+        DEFINE VARIABLE outp    AS LONGCHAR  NO-UNDO.
+        
+        clsfile = NEW ClassFile("FileName", "OEMock.Tests.Util.ListObject").
+        clsfile:TempTables:AddTempTable(NEW OEMock.Reflection.TempTable('ttName')).
+        
+        outp = clsfile:Generate().
+        AssertString:Contains(outp, "DEFINE TEMP-TABLE ttName"). 
+        
         IF VALID-OBJECT(clsfile) THEN DELETE OBJECT clsfile.
     END METHOD.
     

--- a/OEMock/Tests/Reflection/ProcedureFileTester.cls
+++ b/OEMock/Tests/Reflection/ProcedureFileTester.cls
@@ -78,6 +78,17 @@ CLASS OEMock.Tests.Reflection.ProcedureFileTester:
     END METHOD.
     
     @Test.
+    METHOD PUBLIC VOID ConstructorCreatesTempTableList():
+        DEFINE VARIABLE procfile AS ProcedureFile NO-UNDO.
+        
+        procfile = NEW ProcedureFile("FileName").
+        
+        Assert:IsTrue(VALID-OBJECT(procfile:TempTables)).
+        
+        IF VALID-OBJECT(procfile) THEN DELETE OBJECT procfile.
+    END METHOD.
+    
+    @Test.
     METHOD PUBLIC VOID GenerateCreatesUsingStatements():
         DEFINE VARIABLE procFile AS ProcedureFile NO-UNDO.
         
@@ -150,6 +161,20 @@ CLASS OEMock.Tests.Reflection.ProcedureFileTester:
         
         outp = procfile:Generate().
         AssertString:Contains(outp, "DEFINE INPUT PARAMETER ParamName AS CHARACTER NO-UNDO."). 
+        
+        IF VALID-OBJECT(procfile) THEN DELETE OBJECT procfile.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesTempTables():
+        DEFINE VARIABLE procfile AS ProcedureFile NO-UNDO.
+        DEFINE VARIABLE outp     AS LONGCHAR NO-UNDO.
+        
+        procfile = NEW ProcedureFile("FileName").
+        procfile:TempTables:AddTempTable(NEW OEMock.Reflection.TempTable('ttName')).
+        
+        outp = procfile:Generate().
+        AssertString:Contains(outp, "DEFINE TEMP-TABLE ttName"). 
         
         IF VALID-OBJECT(procfile) THEN DELETE OBJECT procfile.
     END METHOD.

--- a/OEMock/Tests/Reflection/TempTableFieldListTester.cls
+++ b/OEMock/Tests/Reflection/TempTableFieldListTester.cls
@@ -1,0 +1,185 @@
+/*------------------------------------------------------------------------
+    File        : TempTableFieldListTester
+    Purpose     : 
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEUnit.Assertion.*.
+USING OEMock.Reflection.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Tests.Reflection.TempTableFieldListTester:
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsDestroyOnDestructToTrue():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        Assert:IsTrue(list:DestroyOnDestruct).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorCreatesBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID AddTempTableFieldIncrementsCounter():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTableField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        drel = NEW TempTableField("TempTableFieldName", "CHARACTER").
+        list:AddTempTableField(drel).
+        Assert:AreEqual(list:Count,1).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID AddItemDoesNotIncrementCounterWhenNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        list:AddTempTableField(?).
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID EmptyListClearsList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTableField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        drel = NEW TempTableField("TempTableFieldName", "CHARACTER").
+        list:AddTempTableField(drel).
+        Assert:AreEqual(list:Count,1).
+        list:EmptyList().
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveFirstIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTableField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        drel = NEW TempTableField("TempTableFieldName", "CHARACTER").
+        list:AddTempTableField(drel).
+        Assert:IsNotNull(list:MoveFirst()).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveFirstIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTableField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        drel = NEW TempTableField("TempTableFieldName", "CHARACTER").
+        Assert:IsNull(list:MoveFirst()).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveLastIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        fiel = NEW TempTableField("TempTableFieldName", "CHARACTER").
+        list:AddTempTableField(fiel).
+        Assert:IsNotNull(list:MoveLast()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveLastIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        fiel = NEW TempTableField("TempTableFieldName", "CHARACTER").
+        Assert:IsNull(list:MoveLast()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        fiel = NEW TempTableField("TempTableFieldName", "CHARACTER").
+        list:AddTempTableField(fiel).
+        Assert:IsNotNull(list:MoveNext()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        fiel = NEW TempTableField("TempTableFieldName", "CHARACTER").
+        Assert:IsNull(list:MoveNext()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextReturnsValidObjectsWithMultipleItemList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        DEFINE VARIABLE res  AS TempTableField NO-UNDO.
+        
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        list:AddTempTableField(NEW TempTableField("Field1", "CHARACTER")).
+        list:AddTempTableField(NEW TempTableField("Field2", "CHARACTER")).
+        list:AddTempTableField(NEW TempTableField("Field3", "CHARACTER")).
+
+        res = list:MoveFirst().
+        AssertString:Contains(res:GetClass():TypeName, 'TempTableField').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.TempTableField')).
+        Assert:AreEqual(res:Name, "Field1").
+
+        res = list:MoveNext().
+        AssertString:Contains(res:GetClass():TypeName, 'TempTableField').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.TempTableField')).
+        Assert:AreEqual(res:Name, "Field2").
+
+        res = list:MoveNext().
+        AssertString:Contains(res:GetClass():TypeName, 'TempTableField').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.TempTableField')).
+        Assert:AreEqual(res:Name, "Field3").
+        
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MovePrevIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        fiel = NEW TempTableField("TempTableFieldName", "CHARACTER").
+        list:AddTempTableField(fiel).
+        Assert:IsNotNull(list:MovePrev()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MovePrevIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableFieldList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableFieldList().
+        fiel = NEW TempTableField("TempTableFieldName", "CHARACTER").
+        Assert:IsNull(list:MovePrev()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/Reflection/TempTableFieldTester.cls
+++ b/OEMock/Tests/Reflection/TempTableFieldTester.cls
@@ -162,10 +162,10 @@ CLASS OEMock.Tests.Reflection.TempTableFieldTester:
         
         DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
         
-        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
-        tfld:INITIAL = "'Initial Value'".
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "INTEGER").
+        tfld:INITIAL = "5".
         
-        AssertString:Contains(tfld:Generate(), "INITIAL 'Initial Value'").
+        AssertString:Contains(tfld:Generate(), "INITIAL 5").
         
         IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
     END METHOD.
@@ -246,6 +246,32 @@ CLASS OEMock.Tests.Reflection.TempTableFieldTester:
         tfld:XMLNodeName = "XMLNodeName".
         
         AssertString:Contains(tfld:Generate(), "XML-NODE-NAME ~"XMLNodeName~"").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateQuotesStringInitials():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        tfld:Initial = "InitialValue".
+        
+        AssertString:Contains(tfld:Generate(), "INITIAL ~"InitialValue~"").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateDoesNotQuoteNullStringInitials():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        tfld:Initial = ?.
+        
+        AssertString:Contains(tfld:Generate(), "INITIAL ?").
         
         IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
     END METHOD.

--- a/OEMock/Tests/Reflection/TempTableFieldTester.cls
+++ b/OEMock/Tests/Reflection/TempTableFieldTester.cls
@@ -1,0 +1,253 @@
+ /*------------------------------------------------------------------------
+    File        : TempTableFieldTester
+    Purpose     : Unit tests for TempTableField class
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEUnit.Assertion.*.
+USING OEMock.Reflection.TempTableField.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Tests.Reflection.TempTableFieldTester:
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsName():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        
+        Assert:AreEqual(tfld:Name, "FieldName").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsDataType():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        
+        Assert:AreEqual(tfld:DataType, "CHARACTER").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsInitialBlank():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        
+        Assert:AreEqual(tfld:Initial, "").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsExtentZero():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        
+        Assert:AreEqual(tfld:Extent, 0).
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsSerializeHiddenFalse():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        
+        Assert:IsFalse(tfld:SerializeHidden).
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsSerializeNameBlank():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        
+        Assert:AreEqual(tfld:SerializeName, "").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsXMLDataTypeBlank():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        
+        Assert:AreEqual(tfld:XMLDataType, "").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsXMLNodeTypeBlank():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        
+        Assert:AreEqual(tfld:XMLNodeType, "").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsXMLNodeNameBlank():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        
+        Assert:AreEqual(tfld:XMLNodeName, "").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ExtentPropertyResetsNullValue():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        tfld:Extent = ?.
+        
+        Assert:AreEqual(tfld:Extent, 0).
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ExtentPropertyResetsNegativeValue():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        tfld:Extent = -1.
+        
+        Assert:AreEqual(tfld:Extent, 0).
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateCreatesBasicField():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        
+        AssertString:Contains(tfld:Generate(), "FIELD FieldName AS CHARACTER").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesInitial():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        tfld:INITIAL = "'Initial Value'".
+        
+        AssertString:Contains(tfld:Generate(), "INITIAL 'Initial Value'").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesExtents():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        tfld:EXTENT = 4.
+        
+        AssertString:Contains(tfld:Generate(), "EXTENT 4").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesSerializeHidden():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        tfld:SerializeHidden = TRUE.
+        
+        AssertString:Contains(tfld:Generate(), "SERIALIZE-HIDDEN").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesSerializeName():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        tfld:SerializeName = "SerializeName".
+        
+        AssertString:Contains(tfld:Generate(), "SERIALIZE-NAME ~"SerializeName~"").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesXMLDataType():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        tfld:XMLDataType = "XMLDataType".
+        
+        AssertString:Contains(tfld:Generate(), "XML-DATA-TYPE ~"XMLDataType~"").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesXMLNodeType ():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        tfld:XMLNodeType = "XMLNodeType".
+        
+        AssertString:Contains(tfld:Generate(), "XML-NODE-TYPE ~"XMLNodeType~"").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesXMLNodeName():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableField("FieldName", "CHARACTER").
+        tfld:XMLNodeName = "XMLNodeName".
+        
+        AssertString:Contains(tfld:Generate(), "XML-NODE-NAME ~"XMLNodeName~"").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/Reflection/TempTableIndexFieldListTester.cls
+++ b/OEMock/Tests/Reflection/TempTableIndexFieldListTester.cls
@@ -1,0 +1,185 @@
+/*------------------------------------------------------------------------
+    File        : TempTableIndexFieldListTester
+    Purpose     : 
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEUnit.Assertion.*.
+USING OEMock.Reflection.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Tests.Reflection.TempTableIndexFieldListTester:
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsDestroyOnDestructToTrue():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        Assert:IsTrue(list:DestroyOnDestruct).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorCreatesBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID AddTempTableIndexFieldIncrementsCounter():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTableIndexField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        drel = NEW TempTableIndexField("TempTableIndexFieldName").
+        list:AddTempTableIndexField(drel).
+        Assert:AreEqual(list:Count,1).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID AddItemDoesNotIncrementCounterWhenNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        list:AddTempTableIndexField(?).
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID EmptyListClearsList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTableIndexField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        drel = NEW TempTableIndexField("TempTableIndexFieldName").
+        list:AddTempTableIndexField(drel).
+        Assert:AreEqual(list:Count,1).
+        list:EmptyList().
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveFirstIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTableIndexField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        drel = NEW TempTableIndexField("TempTableIndexFieldName").
+        list:AddTempTableIndexField(drel).
+        Assert:IsNotNull(list:MoveFirst()).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveFirstIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTableIndexField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        drel = NEW TempTableIndexField("TempTableIndexFieldName").
+        Assert:IsNull(list:MoveFirst()).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveLastIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableIndexField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        fiel = NEW TempTableIndexField("TempTableIndexFieldName").
+        list:AddTempTableIndexField(fiel).
+        Assert:IsNotNull(list:MoveLast()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveLastIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableIndexField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        fiel = NEW TempTableIndexField("TempTableIndexFieldName").
+        Assert:IsNull(list:MoveLast()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableIndexField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        fiel = NEW TempTableIndexField("TempTableIndexFieldName").
+        list:AddTempTableIndexField(fiel).
+        Assert:IsNotNull(list:MoveNext()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableIndexField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        fiel = NEW TempTableIndexField("TempTableIndexFieldName").
+        Assert:IsNull(list:MoveNext()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextReturnsValidObjectsWithMultipleItemList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        DEFINE VARIABLE res  AS TempTableIndexField NO-UNDO.
+        
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        list:AddTempTableIndexField(NEW TempTableIndexField("Index1")).
+        list:AddTempTableIndexField(NEW TempTableIndexField("Index2")).
+        list:AddTempTableIndexField(NEW TempTableIndexField("Index3")).
+
+        res = list:MoveFirst().
+        AssertString:Contains(res:GetClass():TypeName, 'TempTableIndexField').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.TempTableIndexField')).
+        Assert:AreEqual(res:Name, "Index1").
+
+        res = list:MoveNext().
+        AssertString:Contains(res:GetClass():TypeName, 'TempTableIndexField').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.TempTableIndexField')).
+        Assert:AreEqual(res:Name, "Index2").
+
+        res = list:MoveNext().
+        AssertString:Contains(res:GetClass():TypeName, 'TempTableIndexField').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.TempTableIndexField')).
+        Assert:AreEqual(res:Name, "Index3").
+        
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MovePrevIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableIndexField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        fiel = NEW TempTableIndexField("TempTableIndexFieldName").
+        list:AddTempTableIndexField(fiel).
+        Assert:IsNotNull(list:MovePrev()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MovePrevIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexFieldList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableIndexField NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexFieldList().
+        fiel = NEW TempTableIndexField("TempTableIndexFieldName").
+        Assert:IsNull(list:MovePrev()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/Reflection/TempTableIndexFieldTester.cls
+++ b/OEMock/Tests/Reflection/TempTableIndexFieldTester.cls
@@ -1,0 +1,63 @@
+ /*------------------------------------------------------------------------
+    File        : TempTableIndexFieldTester
+    Purpose     : Unit tests for TempTableIndexField class 
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEUnit.Assertion.*.
+USING OEMock.Reflection.TempTableIndexField.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Tests.Reflection.TempTableIndexFieldTester: 
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsName():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndexField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndexField("FieldName").
+        
+        Assert:AreEqual(tfld:Name, "FieldName").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsDescendingFalse():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndexField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndexField("FieldName").
+        
+        Assert:IsFalse(tfld:Descending).
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateCreatesAscendingField():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndexField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndexField("FieldName").
+        
+        AssertString:Contains(tfld:Generate(), "FieldName ASCENDING").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesDescending():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndexField NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndexField("FieldName").
+        tfld:Descending = TRUE.
+        
+        AssertString:Contains(tfld:Generate(), "FieldName DESCENDING").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/Reflection/TempTableIndexListTester.cls
+++ b/OEMock/Tests/Reflection/TempTableIndexListTester.cls
@@ -1,0 +1,185 @@
+/*------------------------------------------------------------------------
+    File        : TempTableIndexListTester
+    Purpose     : 
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEUnit.Assertion.*.
+USING OEMock.Reflection.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Tests.Reflection.TempTableIndexListTester:
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsDestroyOnDestructToTrue():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        Assert:IsTrue(list:DestroyOnDestruct).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorCreatesBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID AddTempTableIndexIncrementsCounter():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTableIndex NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        drel = NEW TempTableIndex("TempTableIndexName").
+        list:AddTempTableIndex(drel).
+        Assert:AreEqual(list:Count,1).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID AddItemDoesNotIncrementCounterWhenNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        list:AddTempTableIndex(?).
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID EmptyListClearsList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTableIndex NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        drel = NEW TempTableIndex("TempTableIndexName").
+        list:AddTempTableIndex(drel).
+        Assert:AreEqual(list:Count,1).
+        list:EmptyList().
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveFirstIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTableIndex NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        drel = NEW TempTableIndex("TempTableIndexName").
+        list:AddTempTableIndex(drel).
+        Assert:IsNotNull(list:MoveFirst()).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveFirstIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTableIndex NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        drel = NEW TempTableIndex("TempTableIndexName").
+        Assert:IsNull(list:MoveFirst()).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveLastIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableIndex NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        fiel = NEW TempTableIndex("TempTableIndexName").
+        list:AddTempTableIndex(fiel).
+        Assert:IsNotNull(list:MoveLast()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveLastIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableIndex NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        fiel = NEW TempTableIndex("TempTableIndexName").
+        Assert:IsNull(list:MoveLast()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableIndex NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        fiel = NEW TempTableIndex("TempTableIndexName").
+        list:AddTempTableIndex(fiel).
+        Assert:IsNotNull(list:MoveNext()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableIndex NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        fiel = NEW TempTableIndex("TempTableIndexName").
+        Assert:IsNull(list:MoveNext()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextReturnsValidObjectsWithMultipleItemList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        DEFINE VARIABLE res  AS TempTableIndex NO-UNDO.
+        
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        list:AddTempTableIndex(NEW TempTableIndex("Index1")).
+        list:AddTempTableIndex(NEW TempTableIndex("Index2")).
+        list:AddTempTableIndex(NEW TempTableIndex("Index3")).
+
+        res = list:MoveFirst().
+        AssertString:Contains(res:GetClass():TypeName, 'TempTableIndex').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.TempTableIndex')).
+        Assert:AreEqual(res:Name, "Index1").
+
+        res = list:MoveNext().
+        AssertString:Contains(res:GetClass():TypeName, 'TempTableIndex').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.TempTableIndex')).
+        Assert:AreEqual(res:Name, "Index2").
+
+        res = list:MoveNext().
+        AssertString:Contains(res:GetClass():TypeName, 'TempTableIndex').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.TempTableIndex')).
+        Assert:AreEqual(res:Name, "Index3").
+        
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MovePrevIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableIndex NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        fiel = NEW TempTableIndex("TempTableIndexName").
+        list:AddTempTableIndex(fiel).
+        Assert:IsNotNull(list:MovePrev()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MovePrevIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableIndexList NO-UNDO.
+        DEFINE VARIABLE fiel AS TempTableIndex NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableIndexList().
+        fiel = NEW TempTableIndex("TempTableIndexName").
+        Assert:IsNull(list:MovePrev()).
+        IF VALID-OBJECT(fiel) THEN DELETE OBJECT fiel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/Reflection/TempTableIndexTester.cls
+++ b/OEMock/Tests/Reflection/TempTableIndexTester.cls
@@ -12,6 +12,18 @@ ROUTINE-LEVEL ON ERROR UNDO, THROW.
 CLASS OEMock.Tests.Reflection.TempTableIndexTester: 
     
     @Test.
+    METHOD PUBLIC VOID ConstructorCreatesFields():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
+        
+        Assert:IsTrue(VALID-OBJECT(tfld:Fields)).
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
     METHOD PUBLIC VOID ConstructorSetsName():
         
         DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
@@ -121,6 +133,22 @@ CLASS OEMock.Tests.Reflection.TempTableIndexTester:
         tfld:WordIndex = TRUE.
         
         AssertString:Contains(tfld:Generate(), "INDEX FieldName IS PRIMARY UNIQUE WORD-INDEX ").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesIndexes():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                         NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndex("Index").
+        tfld:Fields:AddTempTableIndexField(NEW OEMock.Reflection.TempTableIndexField("Field1")).
+        
+        gen = tfld:Generate().
+
+        AssertString:Contains(gen, "Field1 ASCENDING").
         
         IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
     END METHOD.

--- a/OEMock/Tests/Reflection/TempTableIndexTester.cls
+++ b/OEMock/Tests/Reflection/TempTableIndexTester.cls
@@ -78,7 +78,7 @@ CLASS OEMock.Tests.Reflection.TempTableIndexTester:
         
         tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
         
-        AssertString:Contains(tfld:Generate(), "INDEX FieldName ").
+        AssertString:Contains(tfld:Generate(), "INDEX FieldName").
         
         IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
     END METHOD.
@@ -91,7 +91,7 @@ CLASS OEMock.Tests.Reflection.TempTableIndexTester:
         tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
         tfld:Primary = TRUE.
         
-        AssertString:Contains(tfld:Generate(), "INDEX FieldName IS PRIMARY ").
+        AssertString:Contains(tfld:Generate(), "INDEX FieldName IS PRIMARY").
         
         IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
     END METHOD.
@@ -104,7 +104,7 @@ CLASS OEMock.Tests.Reflection.TempTableIndexTester:
         tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
         tfld:Unique = TRUE.
         
-        AssertString:Contains(tfld:Generate(), "INDEX FieldName IS UNIQUE ").
+        AssertString:Contains(tfld:Generate(), "INDEX FieldName IS UNIQUE").
         
         IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
     END METHOD.
@@ -117,7 +117,7 @@ CLASS OEMock.Tests.Reflection.TempTableIndexTester:
         tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
         tfld:WordIndex = TRUE.
         
-        AssertString:Contains(tfld:Generate(), "INDEX FieldName IS WORD-INDEX ").
+        AssertString:Contains(tfld:Generate(), "INDEX FieldName IS WORD-INDEX").
         
         IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
     END METHOD.
@@ -132,13 +132,13 @@ CLASS OEMock.Tests.Reflection.TempTableIndexTester:
         tfld:Unique    = TRUE.
         tfld:WordIndex = TRUE.
         
-        AssertString:Contains(tfld:Generate(), "INDEX FieldName IS PRIMARY UNIQUE WORD-INDEX ").
+        AssertString:Contains(tfld:Generate(), "INDEX FieldName IS PRIMARY UNIQUE WORD-INDEX").
         
         IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
     END METHOD.
     
     @Test.
-    METHOD PUBLIC VOID GenerateObservesIndexes():
+    METHOD PUBLIC VOID GenerateObservesIndexFields():
         
         DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
         DEFINE VARIABLE gen  AS LONGCHAR                         NO-UNDO.

--- a/OEMock/Tests/Reflection/TempTableIndexTester.cls
+++ b/OEMock/Tests/Reflection/TempTableIndexTester.cls
@@ -1,0 +1,128 @@
+ /*------------------------------------------------------------------------
+    File        : TempTableIndexTester
+    Purpose     : Unit tests for TempTableIndex class 
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEUnit.Assertion.*.
+USING OEMock.Reflection.TempTableIndex.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Tests.Reflection.TempTableIndexTester: 
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsName():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
+        
+        Assert:AreEqual(tfld:Name, "FieldName").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsPrimaryFalse():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
+        
+        Assert:IsFalse(tfld:Primary).
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsUniqueFalse():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
+        
+        Assert:IsFalse(tfld:Unique).
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsWordIndexFalse():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
+        
+        Assert:IsFalse(tfld:WordIndex).
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateCreatesBasicIndex():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
+        
+        AssertString:Contains(tfld:Generate(), "INDEX FieldName ").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesPrimary():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
+        tfld:Primary = TRUE.
+        
+        AssertString:Contains(tfld:Generate(), "INDEX FieldName IS PRIMARY ").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesUnique():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
+        tfld:Unique = TRUE.
+        
+        AssertString:Contains(tfld:Generate(), "INDEX FieldName IS UNIQUE ").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesWordIndex():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
+        tfld:WordIndex = TRUE.
+        
+        AssertString:Contains(tfld:Generate(), "INDEX FieldName IS WORD-INDEX ").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesCompoundFlags():
+        
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
+        
+        tfld = NEW OEMock.Reflection.TempTableIndex("FieldName").
+        tfld:Primary   = TRUE.
+        tfld:Unique    = TRUE.
+        tfld:WordIndex = TRUE.
+        
+        AssertString:Contains(tfld:Generate(), "INDEX FieldName IS PRIMARY UNIQUE WORD-INDEX ").
+        
+        IF VALID-OBJECT(tfld) THEN DELETE OBJECT tfld.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/Reflection/TempTableListTester.cls
+++ b/OEMock/Tests/Reflection/TempTableListTester.cls
@@ -1,0 +1,185 @@
+/*------------------------------------------------------------------------
+    File        : TempTableListTester
+    Purpose     : 
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEUnit.Assertion.*.
+USING OEMock.Reflection.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Tests.Reflection.TempTableListTester:
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsDestroyOnDestructToTrue():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableList().
+        Assert:IsTrue(list:DestroyOnDestruct).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorCreatesBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableList().
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID AddTempTableIncrementsCounter():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTable NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableList().
+        drel = NEW TempTable("TempTableName").
+        list:AddTempTable(drel).
+        Assert:AreEqual(list:Count,1).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID AddItemDoesNotIncrementCounterWhenNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableList().
+        list:AddTempTable(?).
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID EmptyListClearsList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTable NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableList().
+        drel = NEW TempTable("TempTableName").
+        list:AddTempTable(drel).
+        Assert:AreEqual(list:Count,1).
+        list:EmptyList().
+        Assert:AreEqual(list:Count,0).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveFirstIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTable NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableList().
+        drel = NEW TempTable("TempTableName").
+        list:AddTempTable(drel).
+        Assert:IsNotNull(list:MoveFirst()).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveFirstIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        DEFINE VARIABLE drel AS TempTable NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableList().
+        drel = NEW TempTable("TempTableName").
+        Assert:IsNull(list:MoveFirst()).
+        IF VALID-OBJECT(drel) THEN DELETE OBJECT drel.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveLastIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        DEFINE VARIABLE ttab AS TempTable NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableList().
+        ttab = NEW TempTable("TempTableName").
+        list:AddTempTable(ttab).
+        Assert:IsNotNull(list:MoveLast()).
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveLastIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        DEFINE VARIABLE ttab AS TempTable NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableList().
+        ttab = NEW TempTable("TempTableName").
+        Assert:IsNull(list:MoveLast()).
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        DEFINE VARIABLE ttab AS TempTable NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableList().
+        ttab = NEW TempTable("TempTableName").
+        list:AddTempTable(ttab).
+        Assert:IsNotNull(list:MoveNext()).
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        DEFINE VARIABLE ttab AS TempTable NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableList().
+        ttab = NEW TempTable("TempTableName").
+        Assert:IsNull(list:MoveNext()).
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MoveNextReturnsValidObjectsWithMultipleItemList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        DEFINE VARIABLE res  AS TempTable NO-UNDO.
+        
+        list = NEW OEMock.Reflection.TempTableList().
+        list:AddTempTable(NEW TempTable('Relation1')).
+        list:AddTempTable(NEW TempTable('Relation2')).
+        list:AddTempTable(NEW TempTable('Relation3')).
+
+        res = list:MoveFirst().
+        AssertString:Contains(res:GetClass():TypeName, 'TempTable').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.TempTable')).
+        Assert:AreEqual(res:Name, "Relation1").
+
+        res = list:MoveNext().
+        AssertString:Contains(res:GetClass():TypeName, 'TempTable').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.TempTable')).
+        Assert:AreEqual(res:Name, "Relation2").
+
+        res = list:MoveNext().
+        AssertString:Contains(res:GetClass():TypeName, 'TempTable').
+        Assert:IsTrue(res:GetClass():IsA('OEMock.Reflection.TempTable')).
+        Assert:AreEqual(res:Name, "Relation3").
+        
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MovePrevIsNotNull():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        DEFINE VARIABLE ttab AS TempTable NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableList().
+        ttab = NEW TempTable("TempTableName").
+        list:AddTempTable(ttab).
+        Assert:IsNotNull(list:MovePrev()).
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID MovePrevIsNullOnBlankList():
+        DEFINE VARIABLE list AS OEMock.Reflection.TempTableList NO-UNDO.
+        DEFINE VARIABLE ttab AS TempTable NO-UNDO.
+        list = NEW OEMock.Reflection.TempTableList().
+        ttab = NEW TempTable("TempTableName").
+        Assert:IsNull(list:MovePrev()).
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+        IF VALID-OBJECT(list) THEN DELETE OBJECT list.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/Reflection/TempTableTester.cls
+++ b/OEMock/Tests/Reflection/TempTableTester.cls
@@ -1,0 +1,169 @@
+ /*------------------------------------------------------------------------
+    File        : TempTableTester
+    Purpose     : Unit tests for TempTable class
+  ----------------------------------------------------------------------*/
+
+USING Progress.Lang.*.
+USING OEUnit.Assertion.*.
+USING OEMock.Reflection.TempTable.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEMock.Tests.Reflection.TempTableTester:
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsName():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        
+        Assert:AreEqual(ttab:Name, "ttTempTable").
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsBlankNamespacePrefix():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        
+        Assert:AreEqual(ttab:NamespacePrefix, "").
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsBlankNamespaceURI():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        
+        Assert:AreEqual(ttab:NamespaceURI, "").
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsNotStatic():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        
+        Assert:IsFalse(ttab:Static).
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID ConstructorSetsNoUndo():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        
+        Assert:IsTrue(ttab:NoUndo).
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateDefinesBasicTempTable():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        
+        gen = ttab:Generate().
+        
+        AssertString:Contains(gen, "DEFINE TEMP-TABLE ttTempTable ").
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesStatic():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        ttab:Static = TRUE.
+        
+        gen = ttab:Generate().
+        
+        AssertString:Contains(gen, "DEFINE STATIC TEMP-TABLE ttTempTable ").
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesNoUndo():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        ttab:NoUndo = TRUE.
+        
+        gen = ttab:Generate().
+        
+        AssertString:Contains(gen, "NO-UNDO").
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesUndo():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        ttab:NoUndo = FALSE.
+        
+        gen = ttab:Generate().
+        
+        AssertString:DoesNotContain(gen, " NO-UNDO ").
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesNamespacePrefix():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        ttab:NamespacePrefix = "MyNameSpacePrefix".
+        
+        gen = ttab:Generate().
+        
+        AssertString:Contains(gen, " NAMESPACE-PREFIX ~"MyNameSpacePrefix~" ").
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesNamespaceURI():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        ttab:NamespaceURI = "MyNameSpaceURI".
+        
+        gen = ttab:Generate().
+       
+        AssertString:Contains(gen, " NAMESPACE-URI ~"MyNameSpaceURI~" ").
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+
+END CLASS.

--- a/OEMock/Tests/Reflection/TempTableTester.cls
+++ b/OEMock/Tests/Reflection/TempTableTester.cls
@@ -24,6 +24,18 @@ CLASS OEMock.Tests.Reflection.TempTableTester:
     END METHOD.
     
     @Test.
+    METHOD PUBLIC VOID ConstructorCreatesIndexes():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        
+        Assert:IsTrue(VALID-OBJECT(ttab:Indexes)).
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
     METHOD PUBLIC VOID ConstructorSetsName():
         
         DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
@@ -191,6 +203,23 @@ CLASS OEMock.Tests.Reflection.TempTableTester:
         gen = ttab:Generate().
 
         AssertString:Contains(gen, "FIELD Field1 AS CHARACTER").
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesIndexes():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableIndex NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        ttab:Indexes:AddTempTableIndex(NEW OEMock.Reflection.TempTableIndex("Index1")).
+        
+        gen = ttab:Generate().
+
+        AssertString:Contains(gen, "INDEX Index1").
         
         IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
     END METHOD.

--- a/OEMock/Tests/Reflection/TempTableTester.cls
+++ b/OEMock/Tests/Reflection/TempTableTester.cls
@@ -12,6 +12,18 @@ ROUTINE-LEVEL ON ERROR UNDO, THROW.
 CLASS OEMock.Tests.Reflection.TempTableTester:
     
     @Test.
+    METHOD PUBLIC VOID ConstructorCreatesFields():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        
+        Assert:IsTrue(VALID-OBJECT(ttab:Fields)).
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
     METHOD PUBLIC VOID ConstructorSetsName():
         
         DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
@@ -145,7 +157,7 @@ CLASS OEMock.Tests.Reflection.TempTableTester:
         
         gen = ttab:Generate().
         
-        AssertString:Contains(gen, " NAMESPACE-PREFIX ~"MyNameSpacePrefix~" ").
+        AssertString:Contains(gen, " NAMESPACE-PREFIX ~"MyNameSpacePrefix~"").
         
         IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
     END METHOD.
@@ -160,8 +172,25 @@ CLASS OEMock.Tests.Reflection.TempTableTester:
         ttab:NamespaceURI = "MyNameSpaceURI".
         
         gen = ttab:Generate().
-       
-        AssertString:Contains(gen, " NAMESPACE-URI ~"MyNameSpaceURI~" ").
+
+        AssertString:Contains(gen, " NAMESPACE-URI ~"MyNameSpaceURI~"").
+        
+        IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID GenerateObservesFields():
+        
+        DEFINE VARIABLE ttab AS OEMock.Reflection.TempTable NO-UNDO.
+        DEFINE VARIABLE tfld AS OEMock.Reflection.TempTableField NO-UNDO.
+        DEFINE VARIABLE gen  AS LONGCHAR                  NO-UNDO.
+        
+        ttab = NEW OEMock.Reflection.TempTable("ttTempTable").
+        ttab:Fields:AddTempTableField(NEW OEMock.Reflection.TempTableField("Field1", "CHARACTER")).
+        
+        gen = ttab:Generate().
+
+        AssertString:Contains(gen, "FIELD Field1 AS CHARACTER").
         
         IF VALID-OBJECT(ttab) THEN DELETE OBJECT ttab.
     END METHOD.


### PR DESCRIPTION
This change allows temp-tables to be defined to work-around the absence of temp-table information in XML-XREF files.
